### PR TITLE
Add Rhode Island primary election results

### DIFF
--- a/2020/20200908__ri__primary__precinct.csv
+++ b/2020/20200908__ri__primary__precinct.csv
@@ -1,0 +1,2291 @@
+office,district,candidate,party,precinct,votes,absentee_votes
+U.S. Senate,,John F. Reed*,D,Bristol 0201,102,54
+U.S. Senate,,John F. Reed*,D,Bristol 0202,117,57
+U.S. Senate,,John F. Reed*,D,Bristol 0203,424,254
+U.S. Senate,,John F. Reed*,D,Bristol 0204,198,103
+U.S. Senate,,John F. Reed*,D,Bristol 0205,155,54
+U.S. Senate,,John F. Reed*,D,Bristol 0206,155,60
+U.S. Senate,,John F. Reed*,D,Bristol 0207,183,113
+U.S. Senate,,John F. Reed*,D,Bristol 0208,141,81
+U.S. Senate,,John F. Reed*,D,Bristol 0209,23,7
+U.S. Senate,,John F. Reed*,D,Burrillville 0301,180,97
+U.S. Senate,,John F. Reed*,D,Burrillville 0303,279,161
+U.S. Senate,,John F. Reed*,D,Burrillville 0306,81,45
+U.S. Senate,,John F. Reed*,D,Burrillville Limited,0,0
+U.S. Senate,,John F. Reed*,D,Central Falls 0401,190,45
+U.S. Senate,,John F. Reed*,D,Central Falls 0402,79,16
+U.S. Senate,,John F. Reed*,D,Central Falls 0403,251,122
+U.S. Senate,,John F. Reed*,D,Central Falls 0404,210,82
+U.S. Senate,,John F. Reed*,D,Central Falls 0405,85,37
+U.S. Senate,,John F. Reed*,D,Central Falls 0406,127,47
+U.S. Senate,,John F. Reed*,D,Central Falls 0407,49,9
+U.S. Senate,,John F. Reed*,D,Central Falls 0408,176,50
+U.S. Senate,,John F. Reed*,D,Charlestown 0501,150,65
+U.S. Senate,,John F. Reed*,D,Charlestown 0502,141,70
+U.S. Senate,,John F. Reed*,D,Charlestown 0503,145,73
+U.S. Senate,,John F. Reed*,D,Charlestown 0504,124,62
+U.S. Senate,,John F. Reed*,D,Charlestown Limited,0,0
+U.S. Senate,,John F. Reed*,D,Coventry 0601,77,26
+U.S. Senate,,John F. Reed*,D,Coventry 0602,22,5
+U.S. Senate,,John F. Reed*,D,Coventry 0603,131,65
+U.S. Senate,,John F. Reed*,D,Coventry 0604,143,58
+U.S. Senate,,John F. Reed*,D,Coventry 0605,68,27
+U.S. Senate,,John F. Reed*,D,Coventry 0606,280,122
+U.S. Senate,,John F. Reed*,D,Coventry 0609,101,38
+U.S. Senate,,John F. Reed*,D,Coventry 0610,62,28
+U.S. Senate,,John F. Reed*,D,Coventry 0611,95,45
+U.S. Senate,,John F. Reed*,D,Coventry 0613,144,76
+U.S. Senate,,John F. Reed*,D,Coventry 0615,273,150
+U.S. Senate,,John F. Reed*,D,Coventry 0617,75,38
+U.S. Senate,,John F. Reed*,D,Coventry 0618,37,25
+U.S. Senate,,John F. Reed*,D,Coventry Limited,0,0
+U.S. Senate,,John F. Reed*,D,Cranston 0701,228,105
+U.S. Senate,,John F. Reed*,D,Cranston 0702,171,52
+U.S. Senate,,John F. Reed*,D,Cranston 0703,156,93
+U.S. Senate,,John F. Reed*,D,Cranston 0704,58,26
+U.S. Senate,,John F. Reed*,D,Cranston 0705,54,19
+U.S. Senate,,John F. Reed*,D,Cranston 0706,217,94
+U.S. Senate,,John F. Reed*,D,Cranston 0707,210,113
+U.S. Senate,,John F. Reed*,D,Cranston 0708,295,152
+U.S. Senate,,John F. Reed*,D,Cranston 0709,277,137
+U.S. Senate,,John F. Reed*,D,Cranston 0710,371,171
+U.S. Senate,,John F. Reed*,D,Cranston 0711,246,113
+U.S. Senate,,John F. Reed*,D,Cranston 0712,319,174
+U.S. Senate,,John F. Reed*,D,Cranston 0713,296,158
+U.S. Senate,,John F. Reed*,D,Cranston 0714,65,30
+U.S. Senate,,John F. Reed*,D,Cranston 0715,234,101
+U.S. Senate,,John F. Reed*,D,Cranston 0716,190,100
+U.S. Senate,,John F. Reed*,D,Cranston 0717,122,61
+U.S. Senate,,John F. Reed*,D,Cranston 0718,124,51
+U.S. Senate,,John F. Reed*,D,Cranston 0719,208,115
+U.S. Senate,,John F. Reed*,D,Cranston 0720,91,39
+U.S. Senate,,John F. Reed*,D,Cranston 0721,326,142
+U.S. Senate,,John F. Reed*,D,Cranston 0722,131,49
+U.S. Senate,,John F. Reed*,D,Cranston 0723,613,264
+U.S. Senate,,John F. Reed*,D,Cranston 0724,577,300
+U.S. Senate,,John F. Reed*,D,Cranston 0725,503,235
+U.S. Senate,,John F. Reed*,D,Cranston 0726,212,89
+U.S. Senate,,John F. Reed*,D,Cranston 0727,318,162
+U.S. Senate,,John F. Reed*,D,Cranston 0728,3,3
+U.S. Senate,,John F. Reed*,D,Cranston 0730,258,112
+U.S. Senate,,John F. Reed*,D,Cranston 0731,247,109
+U.S. Senate,,John F. Reed*,D,Cranston Limited,0,0
+U.S. Senate,,John F. Reed*,D,Cumberland 0801,143,61
+U.S. Senate,,John F. Reed*,D,Cumberland 0802,269,112
+U.S. Senate,,John F. Reed*,D,Cumberland 0803,174,97
+U.S. Senate,,John F. Reed*,D,Cumberland 0804,34,18
+U.S. Senate,,John F. Reed*,D,Cumberland 0809,66,41
+U.S. Senate,,John F. Reed*,D,Cumberland 0812,190,102
+U.S. Senate,,John F. Reed*,D,East Greenwich 0901,55,25
+U.S. Senate,,John F. Reed*,D,East Greenwich 0903,443,226
+U.S. Senate,,John F. Reed*,D,East Greenwich 0905,361,213
+U.S. Senate,,John F. Reed*,D,East Greenwich Limited,0,0
+U.S. Senate,,John F. Reed*,D,East Providence 1003,81,27
+U.S. Senate,,John F. Reed*,D,East Providence 1005,647,349
+U.S. Senate,,John F. Reed*,D,East Providence 1006,14,7
+U.S. Senate,,John F. Reed*,D,East Providence 1007,21,6
+U.S. Senate,,John F. Reed*,D,East Providence 1009,626,311
+U.S. Senate,,John F. Reed*,D,East Providence 1010,370,203
+U.S. Senate,,John F. Reed*,D,East Providence 1012,150,55
+U.S. Senate,,John F. Reed*,D,East Providence 1013,502,249
+U.S. Senate,,John F. Reed*,D,East Providence 1016,158,79
+U.S. Senate,,John F. Reed*,D,Exeter 1101,99,52
+U.S. Senate,,John F. Reed*,D,Exeter 1103,212,125
+U.S. Senate,,John F. Reed*,D,Exeter Limited,0,0
+U.S. Senate,,John F. Reed*,D,Foster 1201,195,119
+U.S. Senate,,John F. Reed*,D,Foster Limited,0,0
+U.S. Senate,,John F. Reed*,D,Glocester 1301,276,152
+U.S. Senate,,John F. Reed*,D,Glocester 1303,36,21
+U.S. Senate,,John F. Reed*,D,Glocester 1304,95,54
+U.S. Senate,,John F. Reed*,D,Glocester Limited,0,0
+U.S. Senate,,John F. Reed*,D,Hopkinton 1401,254,125
+U.S. Senate,,John F. Reed*,D,Hopkinton 1402,173,94
+U.S. Senate,,John F. Reed*,D,Hopkinton 1403,59,36
+U.S. Senate,,John F. Reed*,D,Hopkinton Limited,0,0
+U.S. Senate,,John F. Reed*,D,Jamestown 1501,1155,752
+U.S. Senate,,John F. Reed*,D,Johnston 1601,194,105
+U.S. Senate,,John F. Reed*,D,Johnston 1603,287,138
+U.S. Senate,,John F. Reed*,D,Johnston 1604,135,52
+U.S. Senate,,John F. Reed*,D,Johnston 1605,101,41
+U.S. Senate,,John F. Reed*,D,Johnston 1606,59,26
+U.S. Senate,,John F. Reed*,D,Johnston 1607,68,41
+U.S. Senate,,John F. Reed*,D,Johnston 1608,184,66
+U.S. Senate,,John F. Reed*,D,Johnston 1609,192,97
+U.S. Senate,,John F. Reed*,D,Johnston 1610,426,197
+U.S. Senate,,John F. Reed*,D,Johnston 1611,200,94
+U.S. Senate,,John F. Reed*,D,Johnston 1612,158,72
+U.S. Senate,,John F. Reed*,D,Johnston 1613,123,54
+U.S. Senate,,John F. Reed*,D,Johnston Limited,0,0
+U.S. Senate,,John F. Reed*,D,Little Compton 1801,497,222
+U.S. Senate,,John F. Reed*,D,Middletown 1902,482,260
+U.S. Senate,,John F. Reed*,D,Middletown 1904,524,344
+U.S. Senate,,John F. Reed*,D,Narragansett 2001,66,33
+U.S. Senate,,John F. Reed*,D,Narragansett 2002,494,277
+U.S. Senate,,John F. Reed*,D,Narragansett 2003,423,236
+U.S. Senate,,John F. Reed*,D,Narragansett 2004,516,300
+U.S. Senate,,John F. Reed*,D,Narragansett 2005,403,250
+U.S. Senate,,John F. Reed*,D,Narragansett Limited,0,0
+U.S. Senate,,John F. Reed*,D,New Shoreham 2201,199,86
+U.S. Senate,,John F. Reed*,D,New Shoreham Limited,0,0
+U.S. Senate,,John F. Reed*,D,North Kingstown 2301,202,115
+U.S. Senate,,John F. Reed*,D,North Kingstown 2304,889,480
+U.S. Senate,,John F. Reed*,D,North Kingstown 2306,293,162
+U.S. Senate,,John F. Reed*,D,North Kingstown 2309,1366,796
+U.S. Senate,,John F. Reed*,D,North Kingstown Limited,0,0
+U.S. Senate,,John F. Reed*,D,North Providence 2401,213,69
+U.S. Senate,,John F. Reed*,D,North Providence 2403,388,169
+U.S. Senate,,John F. Reed*,D,North Providence 2405,182,85
+U.S. Senate,,John F. Reed*,D,North Providence 2407,413,124
+U.S. Senate,,John F. Reed*,D,North Providence 2409,77,36
+U.S. Senate,,John F. Reed*,D,North Providence 2410,240,107
+U.S. Senate,,John F. Reed*,D,North Providence 2412,770,299
+U.S. Senate,,John F. Reed*,D,North Providence 2414,121,39
+U.S. Senate,,John F. Reed*,D,North Providence 2415,159,58
+U.S. Senate,,John F. Reed*,D,North Providence 2416,366,156
+U.S. Senate,,John F. Reed*,D,Pawtucket 2601,70,19
+U.S. Senate,,John F. Reed*,D,Pawtucket 2602,142,37
+U.S. Senate,,John F. Reed*,D,Pawtucket 2603,353,154
+U.S. Senate,,John F. Reed*,D,Pawtucket 2604,185,89
+U.S. Senate,,John F. Reed*,D,Pawtucket 2605,88,31
+U.S. Senate,,John F. Reed*,D,Pawtucket 2606,91,38
+U.S. Senate,,John F. Reed*,D,Pawtucket 2607,604,336
+U.S. Senate,,John F. Reed*,D,Pawtucket 2608,501,313
+U.S. Senate,,John F. Reed*,D,Pawtucket 2609,42,22
+U.S. Senate,,John F. Reed*,D,Pawtucket 2610,25,9
+U.S. Senate,,John F. Reed*,D,Pawtucket 2611,118,63
+U.S. Senate,,John F. Reed*,D,Pawtucket 2612,168,76
+U.S. Senate,,John F. Reed*,D,Pawtucket 2613,227,117
+U.S. Senate,,John F. Reed*,D,Pawtucket 2614,168,68
+U.S. Senate,,John F. Reed*,D,Pawtucket 2615,110,39
+U.S. Senate,,John F. Reed*,D,Pawtucket 2616,45,21
+U.S. Senate,,John F. Reed*,D,Pawtucket 2617,56,17
+U.S. Senate,,John F. Reed*,D,Pawtucket 2618,503,227
+U.S. Senate,,John F. Reed*,D,Pawtucket 2619,251,97
+U.S. Senate,,John F. Reed*,D,Pawtucket 2620,422,196
+U.S. Senate,,John F. Reed*,D,Pawtucket 2621,120,43
+U.S. Senate,,John F. Reed*,D,Pawtucket 2622,76,33
+U.S. Senate,,John F. Reed*,D,Pawtucket 2623,100,38
+U.S. Senate,,John F. Reed*,D,Pawtucket 2624,145,64
+U.S. Senate,,John F. Reed*,D,Pawtucket 2625,70,26
+U.S. Senate,,John F. Reed*,D,Pawtucket 2626,29,14
+U.S. Senate,,John F. Reed*,D,Pawtucket 2627,206,94
+U.S. Senate,,John F. Reed*,D,Pawtucket 2628,305,171
+U.S. Senate,,John F. Reed*,D,Pawtucket 2629,361,204
+U.S. Senate,,John F. Reed*,D,Pawtucket 2630,32,9
+U.S. Senate,,John F. Reed*,D,Pawtucket 2631,121,46
+U.S. Senate,,John F. Reed*,D,Portsmouth 2704,483,274
+U.S. Senate,,John F. Reed*,D,Portsmouth 2708,875,538
+U.S. Senate,,John F. Reed*,D,Providence 2801,36,7
+U.S. Senate,,John F. Reed*,D,Providence 2807,0,0
+U.S. Senate,,John F. Reed*,D,Providence 2810,28,18
+U.S. Senate,,John F. Reed*,D,Providence 2811,579,180
+U.S. Senate,,John F. Reed*,D,Providence 2818,638,246
+U.S. Senate,,John F. Reed*,D,Providence 2819,277,124
+U.S. Senate,,John F. Reed*,D,Providence 2820,225,71
+U.S. Senate,,John F. Reed*,D,Providence 2822,37,14
+U.S. Senate,,John F. Reed*,D,Providence 2826,550,217
+U.S. Senate,,John F. Reed*,D,Providence 2830,282,97
+U.S. Senate,,John F. Reed*,D,Providence 2831,746,322
+U.S. Senate,,John F. Reed*,D,Providence 2834,47,23
+U.S. Senate,,John F. Reed*,D,Providence 2835,67,51
+U.S. Senate,,John F. Reed*,D,Providence 2836,3,2
+U.S. Senate,,John F. Reed*,D,Providence 2837,150,66
+U.S. Senate,,John F. Reed*,D,Providence 2838,81,28
+U.S. Senate,,John F. Reed*,D,Providence 2839,209,59
+U.S. Senate,,John F. Reed*,D,Providence 2841,59,16
+U.S. Senate,,John F. Reed*,D,Providence 2842,38,11
+U.S. Senate,,John F. Reed*,D,Providence 2844,309,101
+U.S. Senate,,John F. Reed*,D,Providence 2846,388,123
+U.S. Senate,,John F. Reed*,D,Providence 2847,73,7
+U.S. Senate,,John F. Reed*,D,Providence 2850,309,102
+U.S. Senate,,John F. Reed*,D,Providence 2853,455,191
+U.S. Senate,,John F. Reed*,D,Providence 2854,1059,323
+U.S. Senate,,John F. Reed*,D,Providence 2859,132,36
+U.S. Senate,,John F. Reed*,D,Providence 2863,930,371
+U.S. Senate,,John F. Reed*,D,Providence 2864,57,17
+U.S. Senate,,John F. Reed*,D,Providence 2867,402,168
+U.S. Senate,,John F. Reed*,D,Providence 2868,198,59
+U.S. Senate,,John F. Reed*,D,Providence 2869,95,17
+U.S. Senate,,John F. Reed*,D,Providence 2871,130,24
+U.S. Senate,,John F. Reed*,D,Providence 2875,589,315
+U.S. Senate,,John F. Reed*,D,Providence 2877,50,10
+U.S. Senate,,John F. Reed*,D,Providence Limited 2,2,0
+U.S. Senate,,John F. Reed*,D,Richmond 2902,369,192
+U.S. Senate,,John F. Reed*,D,Richmond Limited,0,0
+U.S. Senate,,John F. Reed*,D,Scituate 3001,137,70
+U.S. Senate,,John F. Reed*,D,Scituate 3002,103,50
+U.S. Senate,,John F. Reed*,D,Scituate 3003,141,73
+U.S. Senate,,John F. Reed*,D,Scituate Limited,0,0
+U.S. Senate,,John F. Reed*,D,Smithfield 3101,262,119
+U.S. Senate,,John F. Reed*,D,Smithfield 3103,448,210
+U.S. Senate,,John F. Reed*,D,Smithfield 3104,218,110
+U.S. Senate,,John F. Reed*,D,Smithfield 3105,450,238
+U.S. Senate,,John F. Reed*,D,South Kingstown 3201,138,62
+U.S. Senate,,John F. Reed*,D,South Kingstown 3202,885,553
+U.S. Senate,,John F. Reed*,D,South Kingstown 3204,1062,560
+U.S. Senate,,John F. Reed*,D,South Kingstown 3207,1462,892
+U.S. Senate,,John F. Reed*,D,South Kingstown 3209,208,113
+U.S. Senate,,John F. Reed*,D,South Kingstown 3210,279,139
+U.S. Senate,,John F. Reed*,D,South Kingstown Limited,0,0
+U.S. Senate,,John F. Reed*,D,Tiverton 3306,390,205
+U.S. Senate,,John F. Reed*,D,Warwick 3501,576,320
+U.S. Senate,,John F. Reed*,D,Warwick 3502,471,220
+U.S. Senate,,John F. Reed*,D,Warwick 3503,180,95
+U.S. Senate,,John F. Reed*,D,Warwick 3504,419,215
+U.S. Senate,,John F. Reed*,D,Warwick 3505,117,53
+U.S. Senate,,John F. Reed*,D,Warwick 3506,102,59
+U.S. Senate,,John F. Reed*,D,Warwick 3507,56,25
+U.S. Senate,,John F. Reed*,D,Warwick 3508,275,106
+U.S. Senate,,John F. Reed*,D,Warwick 3509,76,49
+U.S. Senate,,John F. Reed*,D,Warwick 3510,221,105
+U.S. Senate,,John F. Reed*,D,Warwick 3511,287,160
+U.S. Senate,,John F. Reed*,D,Warwick 3512,191,90
+U.S. Senate,,John F. Reed*,D,Warwick 3513,308,181
+U.S. Senate,,John F. Reed*,D,Warwick 3514,391,199
+U.S. Senate,,John F. Reed*,D,Warwick 3515,418,189
+U.S. Senate,,John F. Reed*,D,Warwick 3516,89,41
+U.S. Senate,,John F. Reed*,D,Warwick 3517,102,51
+U.S. Senate,,John F. Reed*,D,Warwick 3518,338,186
+U.S. Senate,,John F. Reed*,D,Warwick 3519,363,178
+U.S. Senate,,John F. Reed*,D,Warwick 3520,245,130
+U.S. Senate,,John F. Reed*,D,Warwick 3521,205,112
+U.S. Senate,,John F. Reed*,D,Warwick 3522,178,89
+U.S. Senate,,John F. Reed*,D,Warwick 3523,375,210
+U.S. Senate,,John F. Reed*,D,Warwick 3524,180,90
+U.S. Senate,,John F. Reed*,D,Warwick 3525,266,158
+U.S. Senate,,John F. Reed*,D,Warwick 3526,88,58
+U.S. Senate,,John F. Reed*,D,Warwick 3527,271,154
+U.S. Senate,,John F. Reed*,D,Warwick 3528,133,69
+U.S. Senate,,John F. Reed*,D,Warwick 3529,280,162
+U.S. Senate,,John F. Reed*,D,Warwick 3530,398,195
+U.S. Senate,,John F. Reed*,D,Warwick 3531,486,241
+U.S. Senate,,John F. Reed*,D,Warwick 3532,103,53
+U.S. Senate,,John F. Reed*,D,Warwick 3533,140,78
+U.S. Senate,,John F. Reed*,D,Warwick Limited,0,0
+U.S. Senate,,John F. Reed*,D,Westerly 3601,67,33
+U.S. Senate,,John F. Reed*,D,Westerly 3602,147,90
+U.S. Senate,,John F. Reed*,D,Westerly 3603,184,124
+U.S. Senate,,John F. Reed*,D,Westerly 3604,148,98
+U.S. Senate,,John F. Reed*,D,Westerly 3605,172,114
+U.S. Senate,,John F. Reed*,D,Westerly 3606,176,101
+U.S. Senate,,John F. Reed*,D,Westerly 3607,128,70
+U.S. Senate,,John F. Reed*,D,Westerly Limited,0,0
+U.S. Senate,,John F. Reed*,D,West Greenwich 3701,61,32
+U.S. Senate,,John F. Reed*,D,West Greenwich 3702,69,29
+U.S. Senate,,John F. Reed*,D,West Greenwich 3703,40,20
+U.S. Senate,,John F. Reed*,D,West Greenwich 3704,54,29
+U.S. Senate,,John F. Reed*,D,West Greenwich Limited,0,0
+U.S. Senate,,John F. Reed*,D,West Warwick 3801,193,99
+U.S. Senate,,John F. Reed*,D,West Warwick 3802,96,44
+U.S. Senate,,John F. Reed*,D,West Warwick 3803,83,29
+U.S. Senate,,John F. Reed*,D,West Warwick 3804,397,207
+U.S. Senate,,John F. Reed*,D,West Warwick 3805,108,53
+U.S. Senate,,John F. Reed*,D,West Warwick 3806,86,37
+U.S. Senate,,John F. Reed*,D,West Warwick 3807,323,178
+U.S. Senate,,John F. Reed*,D,West Warwick 3808,319,140
+U.S. Senate,,John F. Reed*,D,West Warwick 3809,275,172
+U.S. Senate,,John F. Reed*,D,West Warwick 3810,163,74
+U.S. Senate,,John F. Reed*,D,West Warwick Limited,0,0
+U.S. Senate,,John F. Reed*,D,Woonsocket 3901,14,6
+U.S. Senate,,John F. Reed*,D,Woonsocket 3905,87,29
+U.S. Senate,,John F. Reed*,D,Woonsocket 3907,263,119
+U.S. Senate,,John F. Reed*,D,Woonsocket 3910,289,126
+U.S. Senate,,John F. Reed*,D,Federal Precinct #2,64,56
+U.S. Senate,,John F. Reed*,D,Federal Precinct #2S,10,10
+U.S. House,,David N. Cicilline*,D,Bristol 0201,96,55
+U.S. House,,David N. Cicilline*,D,Bristol 0202,112,57
+U.S. House,,David N. Cicilline*,D,Bristol 0203,423,254
+U.S. House,,David N. Cicilline*,D,Bristol 0204,200,105
+U.S. House,,David N. Cicilline*,D,Bristol 0205,157,57
+U.S. House,,David N. Cicilline*,D,Bristol 0206,151,55
+U.S. House,,David N. Cicilline*,D,Bristol 0207,179,110
+U.S. House,,David N. Cicilline*,D,Bristol 0208,138,80
+U.S. House,,David N. Cicilline*,D,Bristol 0209,26,9
+U.S. House,,David N. Cicilline*,D,Central Falls 0401,212,49
+U.S. House,,David N. Cicilline*,D,Central Falls 0402,92,17
+U.S. House,,David N. Cicilline*,D,Central Falls 0403,274,131
+U.S. House,,David N. Cicilline*,D,Central Falls 0404,227,81
+U.S. House,,David N. Cicilline*,D,Central Falls 0405,95,42
+U.S. House,,David N. Cicilline*,D,Central Falls 0406,134,57
+U.S. House,,David N. Cicilline*,D,Central Falls 0407,56,9
+U.S. House,,David N. Cicilline*,D,Central Falls 0408,202,54
+U.S. House,,David N. Cicilline*,D,Cumberland 0801,143,65
+U.S. House,,David N. Cicilline*,D,Cumberland 0802,261,107
+U.S. House,,David N. Cicilline*,D,Cumberland 0803,169,95
+U.S. House,,David N. Cicilline*,D,Cumberland 0804,30,15
+U.S. House,,David N. Cicilline*,D,Cumberland 0809,59,37
+U.S. House,,David N. Cicilline*,D,Cumberland 0812,183,106
+U.S. House,,David N. Cicilline*,D,East Providence 1003,94,31
+U.S. House,,David N. Cicilline*,D,East Providence 1005,652,355
+U.S. House,,David N. Cicilline*,D,East Providence 1006,13,7
+U.S. House,,David N. Cicilline*,D,East Providence 1007,23,6
+U.S. House,,David N. Cicilline*,D,East Providence 1009,682,324
+U.S. House,,David N. Cicilline*,D,East Providence 1010,399,203
+U.S. House,,David N. Cicilline*,D,East Providence 1012,157,57
+U.S. House,,David N. Cicilline*,D,East Providence 1013,518,254
+U.S. House,,David N. Cicilline*,D,East Providence 1016,157,79
+U.S. House,,David N. Cicilline*,D,Jamestown 1501,1135,745
+U.S. House,,David N. Cicilline*,D,Little Compton 1801,508,222
+U.S. House,,David N. Cicilline*,D,Middletown 1902,493,262
+U.S. House,,David N. Cicilline*,D,Middletown 1904,532,352
+U.S. House,,David N. Cicilline*,D,North Providence 2401,206,64
+U.S. House,,David N. Cicilline*,D,North Providence 2403,355,167
+U.S. House,,David N. Cicilline*,D,North Providence 2405,167,84
+U.S. House,,David N. Cicilline*,D,North Providence 2407,407,126
+U.S. House,,David N. Cicilline*,D,North Providence 2409,76,33
+U.S. House,,David N. Cicilline*,D,North Providence 2410,239,114
+U.S. House,,David N. Cicilline*,D,North Providence 2412,731,291
+U.S. House,,David N. Cicilline*,D,North Providence 2414,120,41
+U.S. House,,David N. Cicilline*,D,North Providence 2415,154,55
+U.S. House,,David N. Cicilline*,D,North Providence 2416,363,156
+U.S. House,,David N. Cicilline*,D,Pawtucket 2601,69,20
+U.S. House,,David N. Cicilline*,D,Pawtucket 2602,152,36
+U.S. House,,David N. Cicilline*,D,Pawtucket 2603,351,158
+U.S. House,,David N. Cicilline*,D,Pawtucket 2604,193,92
+U.S. House,,David N. Cicilline*,D,Pawtucket 2605,98,32
+U.S. House,,David N. Cicilline*,D,Pawtucket 2606,111,37
+U.S. House,,David N. Cicilline*,D,Pawtucket 2607,619,343
+U.S. House,,David N. Cicilline*,D,Pawtucket 2608,519,323
+U.S. House,,David N. Cicilline*,D,Pawtucket 2609,49,27
+U.S. House,,David N. Cicilline*,D,Pawtucket 2610,29,10
+U.S. House,,David N. Cicilline*,D,Pawtucket 2611,138,66
+U.S. House,,David N. Cicilline*,D,Pawtucket 2612,168,74
+U.S. House,,David N. Cicilline*,D,Pawtucket 2613,232,123
+U.S. House,,David N. Cicilline*,D,Pawtucket 2614,190,74
+U.S. House,,David N. Cicilline*,D,Pawtucket 2615,112,40
+U.S. House,,David N. Cicilline*,D,Pawtucket 2616,46,21
+U.S. House,,David N. Cicilline*,D,Pawtucket 2617,54,16
+U.S. House,,David N. Cicilline*,D,Pawtucket 2618,494,223
+U.S. House,,David N. Cicilline*,D,Pawtucket 2619,252,96
+U.S. House,,David N. Cicilline*,D,Pawtucket 2620,423,195
+U.S. House,,David N. Cicilline*,D,Pawtucket 2621,130,48
+U.S. House,,David N. Cicilline*,D,Pawtucket 2622,72,31
+U.S. House,,David N. Cicilline*,D,Pawtucket 2623,109,40
+U.S. House,,David N. Cicilline*,D,Pawtucket 2624,129,58
+U.S. House,,David N. Cicilline*,D,Pawtucket 2625,79,27
+U.S. House,,David N. Cicilline*,D,Pawtucket 2626,37,13
+U.S. House,,David N. Cicilline*,D,Pawtucket 2627,206,94
+U.S. House,,David N. Cicilline*,D,Pawtucket 2628,296,171
+U.S. House,,David N. Cicilline*,D,Pawtucket 2629,350,198
+U.S. House,,David N. Cicilline*,D,Pawtucket 2630,28,9
+U.S. House,,David N. Cicilline*,D,Pawtucket 2631,143,56
+U.S. House,,David N. Cicilline*,D,Portsmouth 2704,485,274
+U.S. House,,David N. Cicilline*,D,Portsmouth 2708,874,541
+U.S. House,,David N. Cicilline*,D,Providence 2801,38,10
+U.S. House,,David N. Cicilline*,D,Providence 2807,0,0
+U.S. House,,David N. Cicilline*,D,Providence 2810,29,19
+U.S. House,,David N. Cicilline*,D,Providence 2811,614,180
+U.S. House,,David N. Cicilline*,D,Providence 2818,674,247
+U.S. House,,David N. Cicilline*,D,Providence 2819,298,125
+U.S. House,,David N. Cicilline*,D,Providence 2820,248,78
+U.S. House,,David N. Cicilline*,D,Providence 2822,41,14
+U.S. House,,David N. Cicilline*,D,Providence 2826,624,233
+U.S. House,,David N. Cicilline*,D,Providence 2830,313,108
+U.S. House,,David N. Cicilline*,D,Providence 2831,871,365
+U.S. House,,David N. Cicilline*,D,Providence 2834,52,24
+U.S. House,,David N. Cicilline*,D,Smithfield 3101,255,116
+U.S. House,,David N. Cicilline*,D,Smithfield 3103,427,202
+U.S. House,,David N. Cicilline*,D,Smithfield 3104,216,112
+U.S. House,,David N. Cicilline*,D,Smithfield 3105,439,243
+U.S. House,,David N. Cicilline*,D,Tiverton 3306,385,204
+U.S. House,,David N. Cicilline*,D,Woonsocket 3901,15,6
+U.S. House,,David N. Cicilline*,D,Woonsocket 3905,97,30
+U.S. House,,David N. Cicilline*,D,Woonsocket 3907,262,121
+U.S. House,,David N. Cicilline*,D,Woonsocket 3910,299,133
+U.S. House,,James R. Langevin*,D,Burrillville 0301,152,87
+U.S. House,,James R. Langevin*,D,Burrillville 0303,215,134
+U.S. House,,James R. Langevin*,D,Burrillville 0306,59,32
+U.S. House,,James R. Langevin*,D,Burrillville Limited,0,0
+U.S. House,,James R. Langevin*,D,Charlestown 0501,126,57
+U.S. House,,James R. Langevin*,D,Charlestown 0502,103,59
+U.S. House,,James R. Langevin*,D,Charlestown 0503,116,54
+U.S. House,,James R. Langevin*,D,Charlestown 0504,110,57
+U.S. House,,James R. Langevin*,D,Charlestown Limited,0,0
+U.S. House,,James R. Langevin*,D,Coventry 0601,56,21
+U.S. House,,James R. Langevin*,D,Coventry 0602,16,3
+U.S. House,,James R. Langevin*,D,Coventry 0603,104,58
+U.S. House,,James R. Langevin*,D,Coventry 0604,106,44
+U.S. House,,James R. Langevin*,D,Coventry 0605,60,24
+U.S. House,,James R. Langevin*,D,Coventry 0606,220,105
+U.S. House,,James R. Langevin*,D,Coventry 0609,72,30
+U.S. House,,James R. Langevin*,D,Coventry 0610,46,22
+U.S. House,,James R. Langevin*,D,Coventry 0611,79,39
+U.S. House,,James R. Langevin*,D,Coventry 0613,115,64
+U.S. House,,James R. Langevin*,D,Coventry 0615,207,120
+U.S. House,,James R. Langevin*,D,Coventry 0617,59,29
+U.S. House,,James R. Langevin*,D,Coventry 0618,30,19
+U.S. House,,James R. Langevin*,D,Coventry Limited,0,0
+U.S. House,,James R. Langevin*,D,Cranston 0701,180,82
+U.S. House,,James R. Langevin*,D,Cranston 0702,144,41
+U.S. House,,James R. Langevin*,D,Cranston 0703,134,77
+U.S. House,,James R. Langevin*,D,Cranston 0704,46,23
+U.S. House,,James R. Langevin*,D,Cranston 0705,48,16
+U.S. House,,James R. Langevin*,D,Cranston 0706,177,83
+U.S. House,,James R. Langevin*,D,Cranston 0707,166,91
+U.S. House,,James R. Langevin*,D,Cranston 0708,239,128
+U.S. House,,James R. Langevin*,D,Cranston 0709,218,112
+U.S. House,,James R. Langevin*,D,Cranston 0710,286,130
+U.S. House,,James R. Langevin*,D,Cranston 0711,201,90
+U.S. House,,James R. Langevin*,D,Cranston 0712,247,147
+U.S. House,,James R. Langevin*,D,Cranston 0713,218,123
+U.S. House,,James R. Langevin*,D,Cranston 0714,50,17
+U.S. House,,James R. Langevin*,D,Cranston 0715,168,70
+U.S. House,,James R. Langevin*,D,Cranston 0716,152,80
+U.S. House,,James R. Langevin*,D,Cranston 0717,83,44
+U.S. House,,James R. Langevin*,D,Cranston 0718,105,46
+U.S. House,,James R. Langevin*,D,Cranston 0719,170,94
+U.S. House,,James R. Langevin*,D,Cranston 0720,75,32
+U.S. House,,James R. Langevin*,D,Cranston 0721,253,110
+U.S. House,,James R. Langevin*,D,Cranston 0722,115,41
+U.S. House,,James R. Langevin*,D,Cranston 0723,460,192
+U.S. House,,James R. Langevin*,D,Cranston 0724,426,217
+U.S. House,,James R. Langevin*,D,Cranston 0725,371,176
+U.S. House,,James R. Langevin*,D,Cranston 0726,162,68
+U.S. House,,James R. Langevin*,D,Cranston 0727,221,108
+U.S. House,,James R. Langevin*,D,Cranston 0728,4,4
+U.S. House,,James R. Langevin*,D,Cranston 0730,191,86
+U.S. House,,James R. Langevin*,D,Cranston 0731,200,86
+U.S. House,,James R. Langevin*,D,Cranston Limited,0,0
+U.S. House,,James R. Langevin*,D,East Greenwich 0901,49,22
+U.S. House,,James R. Langevin*,D,East Greenwich 0903,299,159
+U.S. House,,James R. Langevin*,D,East Greenwich 0905,276,162
+U.S. House,,James R. Langevin*,D,East Greenwich Limited,0,0
+U.S. House,,James R. Langevin*,D,Exeter 1101,71,35
+U.S. House,,James R. Langevin*,D,Exeter 1103,157,91
+U.S. House,,James R. Langevin*,D,Exeter Limited,0,0
+U.S. House,,James R. Langevin*,D,Foster 1201,147,96
+U.S. House,,James R. Langevin*,D,Foster Limited,0,0
+U.S. House,,James R. Langevin*,D,Glocester 1301,213,125
+U.S. House,,James R. Langevin*,D,Glocester 1303,23,15
+U.S. House,,James R. Langevin*,D,Glocester 1304,73,44
+U.S. House,,James R. Langevin*,D,Glocester Limited,0,0
+U.S. House,,James R. Langevin*,D,Hopkinton 1401,205,95
+U.S. House,,James R. Langevin*,D,Hopkinton 1402,129,76
+U.S. House,,James R. Langevin*,D,Hopkinton 1403,48,31
+U.S. House,,James R. Langevin*,D,Hopkinton Limited,0,0
+U.S. House,,James R. Langevin*,D,Johnston 1601,149,89
+U.S. House,,James R. Langevin*,D,Johnston 1603,248,121
+U.S. House,,James R. Langevin*,D,Johnston 1604,102,45
+U.S. House,,James R. Langevin*,D,Johnston 1605,76,34
+U.S. House,,James R. Langevin*,D,Johnston 1606,47,22
+U.S. House,,James R. Langevin*,D,Johnston 1607,54,33
+U.S. House,,James R. Langevin*,D,Johnston 1608,140,60
+U.S. House,,James R. Langevin*,D,Johnston 1609,164,83
+U.S. House,,James R. Langevin*,D,Johnston 1610,331,155
+U.S. House,,James R. Langevin*,D,Johnston 1611,170,85
+U.S. House,,James R. Langevin*,D,Johnston 1612,124,62
+U.S. House,,James R. Langevin*,D,Johnston 1613,86,48
+U.S. House,,James R. Langevin*,D,Johnston Limited,0,0
+U.S. House,,James R. Langevin*,D,Narragansett 2001,56,28
+U.S. House,,James R. Langevin*,D,Narragansett 2002,376,210
+U.S. House,,James R. Langevin*,D,Narragansett 2003,343,192
+U.S. House,,James R. Langevin*,D,Narragansett 2004,412,244
+U.S. House,,James R. Langevin*,D,Narragansett 2005,327,202
+U.S. House,,James R. Langevin*,D,Narragansett Limited,0,0
+U.S. House,,James R. Langevin*,D,New Shoreham 2201,190,77
+U.S. House,,James R. Langevin*,D,New Shoreham Limited,0,0
+U.S. House,,James R. Langevin*,D,North Kingstown 2301,166,100
+U.S. House,,James R. Langevin*,D,North Kingstown 2304,693,378
+U.S. House,,James R. Langevin*,D,North Kingstown 2306,227,133
+U.S. House,,James R. Langevin*,D,North Kingstown 2309,1041,594
+U.S. House,,James R. Langevin*,D,North Kingstown Limited,0,0
+U.S. House,,James R. Langevin*,D,Providence 2835,49,38
+U.S. House,,James R. Langevin*,D,Providence 2836,2,2
+U.S. House,,James R. Langevin*,D,Providence 2837,101,41
+U.S. House,,James R. Langevin*,D,Providence 2838,66,21
+U.S. House,,James R. Langevin*,D,Providence 2839,152,39
+U.S. House,,James R. Langevin*,D,Providence 2841,46,9
+U.S. House,,James R. Langevin*,D,Providence 2842,27,7
+U.S. House,,James R. Langevin*,D,Providence 2844,219,73
+U.S. House,,James R. Langevin*,D,Providence 2846,279,79
+U.S. House,,James R. Langevin*,D,Providence 2847,62,7
+U.S. House,,James R. Langevin*,D,Providence 2850,213,70
+U.S. House,,James R. Langevin*,D,Providence 2853,344,141
+U.S. House,,James R. Langevin*,D,Providence 2854,865,239
+U.S. House,,James R. Langevin*,D,Providence 2859,88,20
+U.S. House,,James R. Langevin*,D,Providence 2863,649,278
+U.S. House,,James R. Langevin*,D,Providence 2864,25,5
+U.S. House,,James R. Langevin*,D,Providence 2867,213,83
+U.S. House,,James R. Langevin*,D,Providence 2868,159,41
+U.S. House,,James R. Langevin*,D,Providence 2869,91,15
+U.S. House,,James R. Langevin*,D,Providence 2871,88,13
+U.S. House,,James R. Langevin*,D,Providence 2875,577,368
+U.S. House,,James R. Langevin*,D,Providence 2877,40,11
+U.S. House,,James R. Langevin*,D,Providence Limited 2,2,0
+U.S. House,,James R. Langevin*,D,Richmond 2902,258,132
+U.S. House,,James R. Langevin*,D,Richmond Limited,0,0
+U.S. House,,James R. Langevin*,D,Scituate 3001,117,58
+U.S. House,,James R. Langevin*,D,Scituate 3002,81,44
+U.S. House,,James R. Langevin*,D,Scituate 3003,113,61
+U.S. House,,James R. Langevin*,D,Scituate Limited,0,0
+U.S. House,,James R. Langevin*,D,South Kingstown 3201,103,48
+U.S. House,,James R. Langevin*,D,South Kingstown 3202,638,400
+U.S. House,,James R. Langevin*,D,South Kingstown 3204,753,390
+U.S. House,,James R. Langevin*,D,South Kingstown 3207,1047,642
+U.S. House,,James R. Langevin*,D,South Kingstown 3209,150,87
+U.S. House,,James R. Langevin*,D,South Kingstown 3210,207,111
+U.S. House,,James R. Langevin*,D,South Kingstown Limited,0,0
+U.S. House,,James R. Langevin*,D,Warwick 3501,418,231
+U.S. House,,James R. Langevin*,D,Warwick 3502,351,163
+U.S. House,,James R. Langevin*,D,Warwick 3503,133,74
+U.S. House,,James R. Langevin*,D,Warwick 3504,303,153
+U.S. House,,James R. Langevin*,D,Warwick 3505,87,42
+U.S. House,,James R. Langevin*,D,Warwick 3506,80,47
+U.S. House,,James R. Langevin*,D,Warwick 3507,42,19
+U.S. House,,James R. Langevin*,D,Warwick 3508,209,83
+U.S. House,,James R. Langevin*,D,Warwick 3509,61,41
+U.S. House,,James R. Langevin*,D,Warwick 3510,175,74
+U.S. House,,James R. Langevin*,D,Warwick 3511,219,133
+U.S. House,,James R. Langevin*,D,Warwick 3512,150,75
+U.S. House,,James R. Langevin*,D,Warwick 3513,239,138
+U.S. House,,James R. Langevin*,D,Warwick 3514,292,155
+U.S. House,,James R. Langevin*,D,Warwick 3515,324,161
+U.S. House,,James R. Langevin*,D,Warwick 3516,70,33
+U.S. House,,James R. Langevin*,D,Warwick 3517,77,40
+U.S. House,,James R. Langevin*,D,Warwick 3518,259,153
+U.S. House,,James R. Langevin*,D,Warwick 3519,277,141
+U.S. House,,James R. Langevin*,D,Warwick 3520,180,95
+U.S. House,,James R. Langevin*,D,Warwick 3521,171,98
+U.S. House,,James R. Langevin*,D,Warwick 3522,138,67
+U.S. House,,James R. Langevin*,D,Warwick 3523,269,155
+U.S. House,,James R. Langevin*,D,Warwick 3524,134,70
+U.S. House,,James R. Langevin*,D,Warwick 3525,201,120
+U.S. House,,James R. Langevin*,D,Warwick 3526,71,45
+U.S. House,,James R. Langevin*,D,Warwick 3527,204,117
+U.S. House,,James R. Langevin*,D,Warwick 3528,101,53
+U.S. House,,James R. Langevin*,D,Warwick 3529,225,142
+U.S. House,,James R. Langevin*,D,Warwick 3530,321,161
+U.S. House,,James R. Langevin*,D,Warwick 3531,391,192
+U.S. House,,James R. Langevin*,D,Warwick 3532,78,40
+U.S. House,,James R. Langevin*,D,Warwick 3533,101,56
+U.S. House,,James R. Langevin*,D,Warwick Limited,0,0
+U.S. House,,James R. Langevin*,D,Westerly 3601,58,28
+U.S. House,,James R. Langevin*,D,Westerly 3602,121,74
+U.S. House,,James R. Langevin*,D,Westerly 3603,155,101
+U.S. House,,James R. Langevin*,D,Westerly 3604,120,75
+U.S. House,,James R. Langevin*,D,Westerly 3605,143,95
+U.S. House,,James R. Langevin*,D,Westerly 3606,146,86
+U.S. House,,James R. Langevin*,D,Westerly 3607,102,56
+U.S. House,,James R. Langevin*,D,Westerly Limited,0,0
+U.S. House,,James R. Langevin*,D,West Greenwich 3701,53,30
+U.S. House,,James R. Langevin*,D,West Greenwich 3702,56,24
+U.S. House,,James R. Langevin*,D,West Greenwich 3703,31,14
+U.S. House,,James R. Langevin*,D,West Greenwich 3704,36,15
+U.S. House,,James R. Langevin*,D,West Greenwich Limited,0,0
+U.S. House,,James R. Langevin*,D,West Warwick 3801,145,75
+U.S. House,,James R. Langevin*,D,West Warwick 3802,82,35
+U.S. House,,James R. Langevin*,D,West Warwick 3803,61,22
+U.S. House,,James R. Langevin*,D,West Warwick 3804,300,161
+U.S. House,,James R. Langevin*,D,West Warwick 3805,81,39
+U.S. House,,James R. Langevin*,D,West Warwick 3806,68,29
+U.S. House,,James R. Langevin*,D,West Warwick 3807,254,145
+U.S. House,,James R. Langevin*,D,West Warwick 3808,254,125
+U.S. House,,James R. Langevin*,D,West Warwick 3809,221,139
+U.S. House,,James R. Langevin*,D,West Warwick 3810,126,71
+U.S. House,,James R. Langevin*,D,West Warwick Limited,0,0
+U.S. House,,James R. Langevin*,D,Federal Precinct #2,41,35
+U.S. House,,James R. Langevin*,D,Federal Precinct #2S,5,5
+U.S. House,,Dylan Conley,D,Burrillville 0301,39,15
+U.S. House,,Dylan Conley,D,Burrillville 0303,79,31
+U.S. House,,Dylan Conley,D,Burrillville 0306,26,14
+U.S. House,,Dylan Conley,D,Burrillville Limited,0,0
+U.S. House,,Dylan Conley,D,Charlestown 0501,30,10
+U.S. House,,Dylan Conley,D,Charlestown 0502,51,12
+U.S. House,,Dylan Conley,D,Charlestown 0503,34,19
+U.S. House,,Dylan Conley,D,Charlestown 0504,23,7
+U.S. House,,Dylan Conley,D,Charlestown Limited,0,0
+U.S. House,,Dylan Conley,D,Coventry 0601,25,5
+U.S. House,,Dylan Conley,D,Coventry 0602,9,2
+U.S. House,,Dylan Conley,D,Coventry 0603,45,16
+U.S. House,,Dylan Conley,D,Coventry 0604,44,14
+U.S. House,,Dylan Conley,D,Coventry 0605,19,4
+U.S. House,,Dylan Conley,D,Coventry 0606,72,19
+U.S. House,,Dylan Conley,D,Coventry 0609,37,10
+U.S. House,,Dylan Conley,D,Coventry 0610,21,8
+U.S. House,,Dylan Conley,D,Coventry 0611,27,10
+U.S. House,,Dylan Conley,D,Coventry 0613,39,16
+U.S. House,,Dylan Conley,D,Coventry 0615,88,36
+U.S. House,,Dylan Conley,D,Coventry 0617,20,8
+U.S. House,,Dylan Conley,D,Coventry 0618,9,4
+U.S. House,,Dylan Conley,D,Coventry Limited,0,0
+U.S. House,,Dylan Conley,D,Cranston 0701,62,25
+U.S. House,,Dylan Conley,D,Cranston 0702,39,13
+U.S. House,,Dylan Conley,D,Cranston 0703,36,22
+U.S. House,,Dylan Conley,D,Cranston 0704,19,6
+U.S. House,,Dylan Conley,D,Cranston 0705,10,4
+U.S. House,,Dylan Conley,D,Cranston 0706,61,13
+U.S. House,,Dylan Conley,D,Cranston 0707,61,32
+U.S. House,,Dylan Conley,D,Cranston 0708,73,28
+U.S. House,,Dylan Conley,D,Cranston 0709,73,28
+U.S. House,,Dylan Conley,D,Cranston 0710,107,44
+U.S. House,,Dylan Conley,D,Cranston 0711,76,33
+U.S. House,,Dylan Conley,D,Cranston 0712,97,33
+U.S. House,,Dylan Conley,D,Cranston 0713,109,41
+U.S. House,,Dylan Conley,D,Cranston 0714,23,14
+U.S. House,,Dylan Conley,D,Cranston 0715,82,35
+U.S. House,,Dylan Conley,D,Cranston 0716,48,24
+U.S. House,,Dylan Conley,D,Cranston 0717,55,19
+U.S. House,,Dylan Conley,D,Cranston 0718,28,6
+U.S. House,,Dylan Conley,D,Cranston 0719,53,25
+U.S. House,,Dylan Conley,D,Cranston 0720,18,8
+U.S. House,,Dylan Conley,D,Cranston 0721,84,34
+U.S. House,,Dylan Conley,D,Cranston 0722,32,14
+U.S. House,,Dylan Conley,D,Cranston 0723,178,82
+U.S. House,,Dylan Conley,D,Cranston 0724,171,80
+U.S. House,,Dylan Conley,D,Cranston 0725,164,66
+U.S. House,,Dylan Conley,D,Cranston 0726,57,21
+U.S. House,,Dylan Conley,D,Cranston 0727,113,57
+U.S. House,,Dylan Conley,D,Cranston 0728,1,1
+U.S. House,,Dylan Conley,D,Cranston 0730,91,32
+U.S. House,,Dylan Conley,D,Cranston 0731,64,29
+U.S. House,,Dylan Conley,D,Cranston Limited,0,0
+U.S. House,,Dylan Conley,D,East Greenwich 0901,11,5
+U.S. House,,Dylan Conley,D,East Greenwich 0903,161,74
+U.S. House,,Dylan Conley,D,East Greenwich 0905,99,54
+U.S. House,,Dylan Conley,D,East Greenwich Limited,0,0
+U.S. House,,Dylan Conley,D,Exeter 1101,29,17
+U.S. House,,Dylan Conley,D,Exeter 1103,68,37
+U.S. House,,Dylan Conley,D,Exeter Limited,0,0
+U.S. House,,Dylan Conley,D,Foster 1201,62,31
+U.S. House,,Dylan Conley,D,Foster Limited,0,0
+U.S. House,,Dylan Conley,D,Glocester 1301,66,27
+U.S. House,,Dylan Conley,D,Glocester 1303,14,6
+U.S. House,,Dylan Conley,D,Glocester 1304,28,12
+U.S. House,,Dylan Conley,D,Glocester Limited,0,0
+U.S. House,,Dylan Conley,D,Hopkinton 1401,70,33
+U.S. House,,Dylan Conley,D,Hopkinton 1402,55,24
+U.S. House,,Dylan Conley,D,Hopkinton 1403,12,5
+U.S. House,,Dylan Conley,D,Hopkinton Limited,0,0
+U.S. House,,Dylan Conley,D,Johnston 1601,83,25
+U.S. House,,Dylan Conley,D,Johnston 1603,81,28
+U.S. House,,Dylan Conley,D,Johnston 1604,48,9
+U.S. House,,Dylan Conley,D,Johnston 1605,41,9
+U.S. House,,Dylan Conley,D,Johnston 1606,18,5
+U.S. House,,Dylan Conley,D,Johnston 1607,25,8
+U.S. House,,Dylan Conley,D,Johnston 1608,77,8
+U.S. House,,Dylan Conley,D,Johnston 1609,88,25
+U.S. House,,Dylan Conley,D,Johnston 1610,164,52
+U.S. House,,Dylan Conley,D,Johnston 1611,78,21
+U.S. House,,Dylan Conley,D,Johnston 1612,73,13
+U.S. House,,Dylan Conley,D,Johnston 1613,55,8
+U.S. House,,Dylan Conley,D,Johnston Limited,0,0
+U.S. House,,Dylan Conley,D,Narragansett 2001,22,7
+U.S. House,,Dylan Conley,D,Narragansett 2002,150,76
+U.S. House,,Dylan Conley,D,Narragansett 2003,127,51
+U.S. House,,Dylan Conley,D,Narragansett 2004,157,72
+U.S. House,,Dylan Conley,D,Narragansett 2005,131,70
+U.S. House,,Dylan Conley,D,Narragansett Limited,0,0
+U.S. House,,Dylan Conley,D,New Shoreham 2201,28,18
+U.S. House,,Dylan Conley,D,New Shoreham Limited,0,0
+U.S. House,,Dylan Conley,D,North Kingstown 2301,53,16
+U.S. House,,Dylan Conley,D,North Kingstown 2304,259,112
+U.S. House,,Dylan Conley,D,North Kingstown 2306,78,28
+U.S. House,,Dylan Conley,D,North Kingstown 2309,395,227
+U.S. House,,Dylan Conley,D,North Kingstown Limited,0,0
+U.S. House,,Dylan Conley,D,Providence 2835,21,16
+U.S. House,,Dylan Conley,D,Providence 2836,1,0
+U.S. House,,Dylan Conley,D,Providence 2837,58,28
+U.S. House,,Dylan Conley,D,Providence 2838,25,8
+U.S. House,,Dylan Conley,D,Providence 2839,73,23
+U.S. House,,Dylan Conley,D,Providence 2841,18,9
+U.S. House,,Dylan Conley,D,Providence 2842,12,4
+U.S. House,,Dylan Conley,D,Providence 2844,141,41
+U.S. House,,Dylan Conley,D,Providence 2846,170,49
+U.S. House,,Dylan Conley,D,Providence 2847,22,1
+U.S. House,,Dylan Conley,D,Providence 2850,121,35
+U.S. House,,Dylan Conley,D,Providence 2853,154,68
+U.S. House,,Dylan Conley,D,Providence 2854,340,106
+U.S. House,,Dylan Conley,D,Providence 2859,53,17
+U.S. House,,Dylan Conley,D,Providence 2863,377,149
+U.S. House,,Dylan Conley,D,Providence 2864,32,15
+U.S. House,,Dylan Conley,D,Providence 2867,208,92
+U.S. House,,Dylan Conley,D,Providence 2868,53,17
+U.S. House,,Dylan Conley,D,Providence 2869,26,4
+U.S. House,,Dylan Conley,D,Providence 2871,52,11
+U.S. House,,Dylan Conley,D,Providence 2875,146,57
+U.S. House,,Dylan Conley,D,Providence 2877,17,1
+U.S. House,,Dylan Conley,D,Providence Limited 2,0,0
+U.S. House,,Dylan Conley,D,Richmond 2902,125,65
+U.S. House,,Dylan Conley,D,Richmond Limited,0,0
+U.S. House,,Dylan Conley,D,Scituate 3001,46,18
+U.S. House,,Dylan Conley,D,Scituate 3002,30,10
+U.S. House,,Dylan Conley,D,Scituate 3003,32,11
+U.S. House,,Dylan Conley,D,Scituate Limited,0,0
+U.S. House,,Dylan Conley,D,South Kingstown 3201,44,15
+U.S. House,,Dylan Conley,D,South Kingstown 3202,317,168
+U.S. House,,Dylan Conley,D,South Kingstown 3204,418,198
+U.S. House,,Dylan Conley,D,South Kingstown 3207,534,305
+U.S. House,,Dylan Conley,D,South Kingstown 3209,72,30
+U.S. House,,Dylan Conley,D,South Kingstown 3210,93,30
+U.S. House,,Dylan Conley,D,South Kingstown Limited,0,0
+U.S. House,,Dylan Conley,D,Warwick 3501,219,103
+U.S. House,,Dylan Conley,D,Warwick 3502,175,67
+U.S. House,,Dylan Conley,D,Warwick 3503,75,27
+U.S. House,,Dylan Conley,D,Warwick 3504,146,68
+U.S. House,,Dylan Conley,D,Warwick 3505,47,14
+U.S. House,,Dylan Conley,D,Warwick 3506,31,15
+U.S. House,,Dylan Conley,D,Warwick 3507,19,9
+U.S. House,,Dylan Conley,D,Warwick 3508,94,27
+U.S. House,,Dylan Conley,D,Warwick 3509,18,8
+U.S. House,,Dylan Conley,D,Warwick 3510,76,38
+U.S. House,,Dylan Conley,D,Warwick 3511,109,40
+U.S. House,,Dylan Conley,D,Warwick 3512,60,21
+U.S. House,,Dylan Conley,D,Warwick 3513,107,49
+U.S. House,,Dylan Conley,D,Warwick 3514,153,51
+U.S. House,,Dylan Conley,D,Warwick 3515,149,42
+U.S. House,,Dylan Conley,D,Warwick 3516,29,8
+U.S. House,,Dylan Conley,D,Warwick 3517,42,14
+U.S. House,,Dylan Conley,D,Warwick 3518,133,45
+U.S. House,,Dylan Conley,D,Warwick 3519,125,41
+U.S. House,,Dylan Conley,D,Warwick 3520,97,43
+U.S. House,,Dylan Conley,D,Warwick 3521,60,24
+U.S. House,,Dylan Conley,D,Warwick 3522,62,26
+U.S. House,,Dylan Conley,D,Warwick 3523,145,70
+U.S. House,,Dylan Conley,D,Warwick 3524,62,25
+U.S. House,,Dylan Conley,D,Warwick 3525,89,46
+U.S. House,,Dylan Conley,D,Warwick 3526,24,14
+U.S. House,,Dylan Conley,D,Warwick 3527,82,39
+U.S. House,,Dylan Conley,D,Warwick 3528,50,21
+U.S. House,,Dylan Conley,D,Warwick 3529,85,32
+U.S. House,,Dylan Conley,D,Warwick 3530,123,41
+U.S. House,,Dylan Conley,D,Warwick 3531,146,58
+U.S. House,,Dylan Conley,D,Warwick 3532,36,15
+U.S. House,,Dylan Conley,D,Warwick 3533,57,22
+U.S. House,,Dylan Conley,D,Warwick Limited,0,0
+U.S. House,,Dylan Conley,D,Westerly 3601,18,5
+U.S. House,,Dylan Conley,D,Westerly 3602,35,20
+U.S. House,,Dylan Conley,D,Westerly 3603,42,27
+U.S. House,,Dylan Conley,D,Westerly 3604,38,26
+U.S. House,,Dylan Conley,D,Westerly 3605,37,22
+U.S. House,,Dylan Conley,D,Westerly 3606,46,21
+U.S. House,,Dylan Conley,D,Westerly 3607,37,16
+U.S. House,,Dylan Conley,D,Westerly Limited,0,0
+U.S. House,,Dylan Conley,D,West Greenwich 3701,16,2
+U.S. House,,Dylan Conley,D,West Greenwich 3702,15,4
+U.S. House,,Dylan Conley,D,West Greenwich 3703,11,6
+U.S. House,,Dylan Conley,D,West Greenwich 3704,23,16
+U.S. House,,Dylan Conley,D,West Greenwich Limited,0,0
+U.S. House,,Dylan Conley,D,West Warwick 3801,68,25
+U.S. House,,Dylan Conley,D,West Warwick 3802,29,12
+U.S. House,,Dylan Conley,D,West Warwick 3803,24,8
+U.S. House,,Dylan Conley,D,West Warwick 3804,138,50
+U.S. House,,Dylan Conley,D,West Warwick 3805,35,13
+U.S. House,,Dylan Conley,D,West Warwick 3806,30,11
+U.S. House,,Dylan Conley,D,West Warwick 3807,100,34
+U.S. House,,Dylan Conley,D,West Warwick 3808,98,23
+U.S. House,,Dylan Conley,D,West Warwick 3809,77,38
+U.S. House,,Dylan Conley,D,West Warwick 3810,54,4
+U.S. House,,Dylan Conley,D,West Warwick Limited,0,0
+U.S. House,,Dylan Conley,D,Federal Precinct #2,25,23
+U.S. House,,Dylan Conley,D,Federal Precinct #2S,5,5
+State Senate,,Maryellen Goodwin*,D,Providence 2801,44,11
+State Senate,,Maryellen Goodwin*,D,Providence 2811,537,178
+State Senate,,Maryellen Goodwin*,D,Providence 2819,281,122
+State Senate,,Maryellen Goodwin*,D,Providence 2835,54,42
+State Senate,,Maryellen Goodwin*,D,Providence 2837,112,37
+State Senate,,Maryellen Goodwin*,D,Providence 2841,43,12
+State Senate,,Maryellen Goodwin*,D,Providence 2842,29,7
+State Senate,,Maryellen Goodwin*,D,Providence 2853,392,164
+State Senate,,Maryellen Goodwin*,D,Providence 2859,109,20
+State Senate,,Evan A. Lemoine,D,Providence 2801,4,0
+State Senate,,Evan A. Lemoine,D,Providence 2811,121,21
+State Senate,,Evan A. Lemoine,D,Providence 2819,44,14
+State Senate,,Evan A. Lemoine,D,Providence 2835,16,12
+State Senate,,Evan A. Lemoine,D,Providence 2837,58,33
+State Senate,,Evan A. Lemoine,D,Providence 2841,21,6
+State Senate,,Evan A. Lemoine,D,Providence 2842,9,3
+State Senate,,Evan A. Lemoine,D,Providence 2853,108,44
+State Senate,,Evan A. Lemoine,D,Providence 2859,38,17
+State Senate,,Ana B. Quezada*,D,Providence 2822,39,13
+State Senate,,Ana B. Quezada*,D,Providence 2826,563,220
+State Senate,,Ana B. Quezada*,D,Providence 2864,55,17
+State Senate,,Ana B. Quezada*,D,Providence 2871,125,24
+State Senate,,Dominick J. Ruggerio*,D,North Providence 2401,110,23
+State Senate,,Dominick J. Ruggerio*,D,North Providence 2403,343,135
+State Senate,,Dominick J. Ruggerio*,D,North Providence 2405,106,39
+State Senate,,Dominick J. Ruggerio*,D,North Providence 2410,207,86
+State Senate,,Dominick J. Ruggerio*,D,North Providence 2412,698,234
+State Senate,,Dominick J. Ruggerio*,D,North Providence 2414,86,21
+State Senate,,Dominick J. Ruggerio*,D,Providence 2820,124,50
+State Senate,,Dominick J. Ruggerio*,D,Providence 2844,127,29
+State Senate,,Dominick J. Ruggerio*,D,Providence 2846,173,55
+State Senate,,"Leonardo A. Cioe, Jr.",D,North Providence 2401,173,51
+State Senate,,"Leonardo A. Cioe, Jr.",D,North Providence 2403,164,63
+State Senate,,"Leonardo A. Cioe, Jr.",D,North Providence 2405,110,50
+State Senate,,"Leonardo A. Cioe, Jr.",D,North Providence 2410,90,31
+State Senate,,"Leonardo A. Cioe, Jr.",D,North Providence 2412,362,115
+State Senate,,"Leonardo A. Cioe, Jr.",D,North Providence 2414,67,23
+State Senate,,"Leonardo A. Cioe, Jr.",D,Providence 2820,150,38
+State Senate,,"Leonardo A. Cioe, Jr.",D,Providence 2844,236,84
+State Senate,,"Leonardo A. Cioe, Jr.",D,Providence 2846,281,75
+State Senate,,Jo-Ann Ryan,D,Providence 2838,45,13
+State Senate,,Jo-Ann Ryan,D,Providence 2847,42,4
+State Senate,,Jo-Ann Ryan,D,Providence 2854,380,94
+State Senate,,Jo-Ann Ryan,D,Providence 2863,264,126
+State Senate,,Jo-Ann Ryan,D,Providence 2867,81,18
+State Senate,,Samuel W. Bell,D,Providence 2838,49,18
+State Senate,,Samuel W. Bell,D,Providence 2847,51,5
+State Senate,,Samuel W. Bell,D,Providence 2854,877,275
+State Senate,,Samuel W. Bell,D,Providence 2863,812,318
+State Senate,,Samuel W. Bell,D,Providence 2867,350,160
+State Senate,,Harold M. Metts*,D,Providence 2807,0,0
+State Senate,,Harold M. Metts*,D,Providence 2810,6,2
+State Senate,,Harold M. Metts*,D,Providence 2818,164,44
+State Senate,,Harold M. Metts*,D,Providence 2830,130,37
+State Senate,,Harold M. Metts*,D,Providence 2831,495,217
+State Senate,,Harold M. Metts*,D,Providence 2836,0,0
+State Senate,,Harold M. Metts*,D,Providence 2839,109,24
+State Senate,,Harold M. Metts*,D,Providence 2868,107,31
+State Senate,,Tiara T. Mack,D,Providence 2807,0,0
+State Senate,,Tiara T. Mack,D,Providence 2810,27,18
+State Senate,,Tiara T. Mack,D,Providence 2818,561,220
+State Senate,,Tiara T. Mack,D,Providence 2830,214,80
+State Senate,,Tiara T. Mack,D,Providence 2831,449,191
+State Senate,,Tiara T. Mack,D,Providence 2836,3,2
+State Senate,,Tiara T. Mack,D,Providence 2839,129,37
+State Senate,,Tiara T. Mack,D,Providence 2868,123,30
+State Senate,,Frank A. Ciccone*,D,Providence 2850,281,88
+State Senate,,Frank A. Ciccone*,D,Providence 2869,91,18
+State Senate,,Frank A. Ciccone*,D,Providence 2875,551,291
+State Senate,,Frank A. Ciccone*,D,Providence 2877,50,12
+State Senate,,Sandra C. Cano*,D,Pawtucket 2612,171,70
+State Senate,,Sandra C. Cano*,D,Pawtucket 2613,216,112
+State Senate,,Sandra C. Cano*,D,Pawtucket 2614,179,72
+State Senate,,Sandra C. Cano*,D,Pawtucket 2615,105,38
+State Senate,,Sandra C. Cano*,D,Pawtucket 2618,468,215
+State Senate,,Sandra C. Cano*,D,Pawtucket 2619,237,91
+State Senate,,Sandra C. Cano*,D,Pawtucket 2620,414,188
+State Senate,,Sandra C. Cano*,D,Pawtucket 2621,115,42
+State Senate,,Sandra C. Cano*,D,Pawtucket 2624,132,58
+State Senate,,Sandra C. Cano*,D,Pawtucket 2625,75,26
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3801,92,45
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3802,60,27
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3803,44,18
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3804,223,101
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3805,54,26
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3807,210,114
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3808,150,76
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3809,151,99
+State Senate,,Geoffrey E. Rousselle*,D,West Warwick 3810,82,44
+State Senate,,John P. Burke,D,West Warwick 3801,128,57
+State Senate,,John P. Burke,D,West Warwick 3802,50,21
+State Senate,,John P. Burke,D,West Warwick 3803,41,11
+State Senate,,John P. Burke,D,West Warwick 3804,222,109
+State Senate,,John P. Burke,D,West Warwick 3805,66,26
+State Senate,,John P. Burke,D,West Warwick 3807,146,64
+State Senate,,John P. Burke,D,West Warwick 3808,203,68
+State Senate,,John P. Burke,D,West Warwick 3809,147,74
+State Senate,,John P. Burke,D,West Warwick 3810,103,31
+State Senate,,"Walter S. Felag, Jr.*",D,Bristol 0201,94,51
+State Senate,,"Walter S. Felag, Jr.*",D,Bristol 0205,146,48
+State Senate,,"Walter S. Felag, Jr.*",D,Bristol 0206,154,55
+State Senate,,James Arthur Seveney*,D,Bristol 0202,108,54
+State Senate,,James Arthur Seveney*,D,Bristol 0207,165,102
+State Senate,,James Arthur Seveney*,D,Bristol 0208,131,78
+State Senate,,James Arthur Seveney*,D,Portsmouth 2704,455,259
+State Senate,,James Arthur Seveney*,D,Portsmouth 2708,845,518
+State Senate,,Louis P. DiPalma*,D,Little Compton 1801,454,199
+State Senate,,Louis P. DiPalma*,D,Middletown 1902,471,247
+State Senate,,Louis P. DiPalma*,D,Middletown 1904,512,335
+State Senate,,Louis P. DiPalma*,D,Tiverton 3306,365,188
+State Senate,,Dawn M. Euer*,D,Jamestown 1501,1112,734
+State Senate,,Valarie J. Lawson*,D,East Providence 1003,79,28
+State Senate,,Valarie J. Lawson*,D,East Providence 1009,591,294
+State Senate,,Valarie J. Lawson*,D,East Providence 1010,341,184
+State Senate,,Herbert P. Weiss*,D,North Providence 2415,31,11
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2601,13,4
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2602,39,13
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2603,100,48
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2604,46,19
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2607,169,81
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2608,87,42
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2609,17,10
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2626,11,1
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2627,94,41
+State Senate,,Herbert P. Weiss*,D,Pawtucket 2631,28,9
+State Senate,,"Robert H. Morris, Jr.",D,North Providence 2415,111,37
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2601,26,3
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2602,25,8
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2603,101,21
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2604,43,7
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2607,35,14
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2608,24,16
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2609,5,1
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2626,6,1
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2627,40,11
+State Senate,,"Robert H. Morris, Jr.",D,Pawtucket 2631,15,3
+State Senate,,Meghan E. Kallman,D,North Providence 2415,54,18
+State Senate,,Meghan E. Kallman,D,Pawtucket 2601,47,17
+State Senate,,Meghan E. Kallman,D,Pawtucket 2602,80,19
+State Senate,,Meghan E. Kallman,D,Pawtucket 2603,202,95
+State Senate,,Meghan E. Kallman,D,Pawtucket 2604,123,62
+State Senate,,Meghan E. Kallman,D,Pawtucket 2607,458,260
+State Senate,,Meghan E. Kallman,D,Pawtucket 2608,444,280
+State Senate,,Meghan E. Kallman,D,Pawtucket 2609,28,16
+State Senate,,Meghan E. Kallman,D,Pawtucket 2626,21,12
+State Senate,,Meghan E. Kallman,D,Pawtucket 2627,102,48
+State Senate,,Meghan E. Kallman,D,Pawtucket 2631,103,43
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0401,85,18
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0402,44,7
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0403,129,56
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0404,99,38
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0405,27,9
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0406,67,20
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0407,29,1
+State Senate,,Elizabeth A. Crowley*,D,Central Falls 0408,73,21
+State Senate,,Elizabeth A. Crowley*,D,Pawtucket 2605,59,28
+State Senate,,Elizabeth A. Crowley*,D,Pawtucket 2606,62,24
+State Senate,,Elizabeth A. Crowley*,D,Pawtucket 2610,12,3
+State Senate,,Elizabeth A. Crowley*,D,Pawtucket 2611,82,35
+State Senate,,Jonathon Acosta,D,Central Falls 0401,125,38
+State Senate,,Jonathon Acosta,D,Central Falls 0402,58,15
+State Senate,,Jonathon Acosta,D,Central Falls 0403,180,95
+State Senate,,Jonathon Acosta,D,Central Falls 0404,132,50
+State Senate,,Jonathon Acosta,D,Central Falls 0405,77,38
+State Senate,,Jonathon Acosta,D,Central Falls 0406,82,37
+State Senate,,Jonathon Acosta,D,Central Falls 0407,31,8
+State Senate,,Jonathon Acosta,D,Central Falls 0408,149,38
+State Senate,,Jonathon Acosta,D,Pawtucket 2605,35,6
+State Senate,,Jonathon Acosta,D,Pawtucket 2606,49,8
+State Senate,,Jonathon Acosta,D,Pawtucket 2610,13,4
+State Senate,,Jonathon Acosta,D,Pawtucket 2611,42,26
+State Senate,,Leslie Estrada,D,Central Falls 0401,49,4
+State Senate,,Leslie Estrada,D,Central Falls 0402,13,0
+State Senate,,Leslie Estrada,D,Central Falls 0403,29,7
+State Senate,,Leslie Estrada,D,Central Falls 0404,24,3
+State Senate,,Leslie Estrada,D,Central Falls 0405,8,1
+State Senate,,Leslie Estrada,D,Central Falls 0406,7,1
+State Senate,,Leslie Estrada,D,Central Falls 0407,7,0
+State Senate,,Leslie Estrada,D,Central Falls 0408,12,4
+State Senate,,Leslie Estrada,D,Pawtucket 2605,10,0
+State Senate,,Leslie Estrada,D,Pawtucket 2606,9,4
+State Senate,,Leslie Estrada,D,Pawtucket 2610,3,3
+State Senate,,Leslie Estrada,D,Pawtucket 2611,16,4
+State Senate,,"John Douglas Barr, II",D,North Providence 2416,293,132
+State Senate,,"William J. Conley, Jr.*",D,East Providence 1005,306,184
+State Senate,,"William J. Conley, Jr.*",D,East Providence 1006,8,2
+State Senate,,"William J. Conley, Jr.*",D,East Providence 1007,7,0
+State Senate,,"William J. Conley, Jr.*",D,East Providence 1012,45,22
+State Senate,,"William J. Conley, Jr.*",D,East Providence 1013,170,100
+State Senate,,"William J. Conley, Jr.*",D,East Providence 1016,72,38
+State Senate,,"William J. Conley, Jr.*",D,Pawtucket 2616,16,7
+State Senate,,"William J. Conley, Jr.*",D,Pawtucket 2617,26,8
+State Senate,,"William J. Conley, Jr.*",D,Pawtucket 2622,33,15
+State Senate,,"William J. Conley, Jr.*",D,Pawtucket 2623,38,16
+State Senate,,"William J. Conley, Jr.*",D,Pawtucket 2628,161,92
+State Senate,,"William J. Conley, Jr.*",D,Pawtucket 2629,180,108
+State Senate,,"William J. Conley, Jr.*",D,Pawtucket 2630,16,4
+State Senate,,Cynthia M. Mendes,D,East Providence 1005,434,194
+State Senate,,Cynthia M. Mendes,D,East Providence 1006,6,4
+State Senate,,Cynthia M. Mendes,D,East Providence 1007,17,6
+State Senate,,Cynthia M. Mendes,D,East Providence 1012,138,37
+State Senate,,Cynthia M. Mendes,D,East Providence 1013,416,165
+State Senate,,Cynthia M. Mendes,D,East Providence 1016,114,45
+State Senate,,Cynthia M. Mendes,D,Pawtucket 2616,36,14
+State Senate,,Cynthia M. Mendes,D,Pawtucket 2617,36,12
+State Senate,,Cynthia M. Mendes,D,Pawtucket 2622,48,18
+State Senate,,Cynthia M. Mendes,D,Pawtucket 2623,75,23
+State Senate,,Cynthia M. Mendes,D,Pawtucket 2628,174,86
+State Senate,,Cynthia M. Mendes,D,Pawtucket 2629,212,103
+State Senate,,Cynthia M. Mendes,D,Pawtucket 2630,21,7
+State Senate,,Ryan W. Pearson*,D,Cumberland 0801,136,59
+State Senate,,Ryan W. Pearson*,D,Cumberland 0812,162,92
+State Senate,,Roger A. Picard*,D,Cumberland 0802,258,105
+State Senate,,Roger A. Picard*,D,Cumberland 0803,168,92
+State Senate,,Roger A. Picard*,D,Cumberland 0804,33,16
+State Senate,,Roger A. Picard*,D,Cumberland 0809,70,41
+State Senate,,Roger A. Picard*,D,Woonsocket 3901,16,6
+State Senate,,Roger A. Picard*,D,Woonsocket 3905,90,30
+State Senate,,Roger A. Picard*,D,Woonsocket 3910,303,126
+State Senate,,Stephen R. Archambault*,D,Johnston 1606,30,15
+State Senate,,Stephen R. Archambault*,D,North Providence 2407,297,64
+State Senate,,Stephen R. Archambault*,D,North Providence 2409,57,25
+State Senate,,Stephen R. Archambault*,D,Smithfield 3101,201,79
+State Senate,,Stephen R. Archambault*,D,Smithfield 3103,316,133
+State Senate,,Stephen R. Archambault*,D,Smithfield 3104,137,62
+State Senate,,Stephen R. Archambault*,D,Smithfield 3105,304,137
+State Senate,,Melanie G. DuPont,D,Johnston 1606,27,10
+State Senate,,Melanie G. DuPont,D,North Providence 2407,218,71
+State Senate,,Melanie G. DuPont,D,North Providence 2409,33,11
+State Senate,,Melanie G. DuPont,D,Smithfield 3101,107,46
+State Senate,,Melanie G. DuPont,D,Smithfield 3103,206,92
+State Senate,,Melanie G. DuPont,D,Smithfield 3104,120,60
+State Senate,,Melanie G. DuPont,D,Smithfield 3105,216,112
+State Senate,,Paul A. Roselli*,D,Burrillville 0301,169,88
+State Senate,,Paul A. Roselli*,D,Burrillville 0303,272,159
+State Senate,,Paul A. Roselli*,D,Burrillville 0306,76,41
+State Senate,,Paul A. Roselli*,D,Glocester 1301,260,142
+State Senate,,Paul A. Roselli*,D,Glocester 1303,35,20
+State Senate,,Paul A. Roselli*,D,Glocester 1304,84,46
+State Senate,,Melissa A. Murray*,D,Woonsocket 3907,259,110
+State Senate,,"Frank Lombardo, III*",D,Johnston 1601,188,99
+State Senate,,"Frank Lombardo, III*",D,Johnston 1603,276,129
+State Senate,,"Frank Lombardo, III*",D,Johnston 1604,131,48
+State Senate,,"Frank Lombardo, III*",D,Johnston 1605,99,38
+State Senate,,"Frank Lombardo, III*",D,Johnston 1607,68,39
+State Senate,,"Frank Lombardo, III*",D,Johnston 1608,182,58
+State Senate,,"Frank Lombardo, III*",D,Johnston 1609,193,94
+State Senate,,"Frank Lombardo, III*",D,Johnston 1610,404,167
+State Senate,,"Frank Lombardo, III*",D,Johnston 1611,190,82
+State Senate,,"Frank Lombardo, III*",D,Johnston 1612,169,70
+State Senate,,"Frank Lombardo, III*",D,Johnston 1613,121,52
+State Senate,,Frank S. Lombardi*,D,Cranston 0701,226,102
+State Senate,,Frank S. Lombardi*,D,Cranston 0702,163,47
+State Senate,,Frank S. Lombardi*,D,Cranston 0703,152,87
+State Senate,,Frank S. Lombardi*,D,Cranston 0706,210,91
+State Senate,,Frank S. Lombardi*,D,Cranston 0707,197,106
+State Senate,,Frank S. Lombardi*,D,Cranston 0716,171,91
+State Senate,,Frank S. Lombardi*,D,Cranston 0730,240,104
+State Senate,,Frank S. Lombardi*,D,Cranston 0731,244,104
+State Senate,,Hanna M. Gallo*,D,Cranston 0708,275,135
+State Senate,,Hanna M. Gallo*,D,Cranston 0709,252,124
+State Senate,,Hanna M. Gallo*,D,Cranston 0710,339,155
+State Senate,,Hanna M. Gallo*,D,Cranston 0711,225,98
+State Senate,,Hanna M. Gallo*,D,Cranston 0712,287,161
+State Senate,,Hanna M. Gallo*,D,Cranston 0713,283,150
+State Senate,,Hanna M. Gallo*,D,Cranston 0717,120,59
+State Senate,,Hanna M. Gallo*,D,Cranston 0718,120,49
+State Senate,,Hanna M. Gallo*,D,Cranston 0719,204,107
+State Senate,,Hanna M. Gallo*,D,Cranston 0720,86,37
+State Senate,,Hanna M. Gallo*,D,Cranston 0728,3,3
+State Senate,,Hanna M. Gallo*,D,West Warwick 3806,79,32
+State Senate,,Joshua Miller*,D,Cranston 0704,54,25
+State Senate,,Joshua Miller*,D,Cranston 0705,47,15
+State Senate,,Joshua Miller*,D,Cranston 0714,60,28
+State Senate,,Joshua Miller*,D,Cranston 0715,211,95
+State Senate,,Joshua Miller*,D,Cranston 0721,305,132
+State Senate,,Joshua Miller*,D,Cranston 0722,127,44
+State Senate,,Joshua Miller*,D,Cranston 0723,587,256
+State Senate,,Joshua Miller*,D,Cranston 0724,560,294
+State Senate,,Joshua Miller*,D,Cranston 0725,476,223
+State Senate,,Joshua Miller*,D,Cranston 0726,199,81
+State Senate,,Joshua Miller*,D,Cranston 0727,310,157
+State Senate,,Joshua Miller*,D,Providence 2834,42,19
+State Senate,,Michael J. McCaffrey*,D,Warwick 3501,308,167
+State Senate,,Michael J. McCaffrey*,D,Warwick 3502,243,94
+State Senate,,Michael J. McCaffrey*,D,Warwick 3503,105,51
+State Senate,,Michael J. McCaffrey*,D,Warwick 3512,129,65
+State Senate,,Michael J. McCaffrey*,D,Warwick 3513,260,155
+State Senate,,Michael J. McCaffrey*,D,Warwick 3514,289,139
+State Senate,,Michael J. McCaffrey*,D,Warwick 3515,306,137
+State Senate,,Michael J. McCaffrey*,D,Warwick 3516,62,31
+State Senate,,Michael J. McCaffrey*,D,Warwick 3517,93,38
+State Senate,,Michael J. McCaffrey*,D,Warwick 3521,157,90
+State Senate,,Jennifer T. Rourke,D,Warwick 3501,336,168
+State Senate,,Jennifer T. Rourke,D,Warwick 3502,287,137
+State Senate,,Jennifer T. Rourke,D,Warwick 3503,105,50
+State Senate,,Jennifer T. Rourke,D,Warwick 3512,84,33
+State Senate,,Jennifer T. Rourke,D,Warwick 3513,95,33
+State Senate,,Jennifer T. Rourke,D,Warwick 3514,170,73
+State Senate,,Jennifer T. Rourke,D,Warwick 3515,178,67
+State Senate,,Jennifer T. Rourke,D,Warwick 3516,39,10
+State Senate,,Jennifer T. Rourke,D,Warwick 3517,29,17
+State Senate,,Jennifer T. Rourke,D,Warwick 3521,80,35
+State Senate,,Jeanine Calkin*,D,Warwick 3506,75,42
+State Senate,,Jeanine Calkin*,D,Warwick 3507,25,12
+State Senate,,Jeanine Calkin*,D,Warwick 3518,183,103
+State Senate,,Jeanine Calkin*,D,Warwick 3519,226,112
+State Senate,,Jeanine Calkin*,D,Warwick 3520,165,90
+State Senate,,Jeanine Calkin*,D,Warwick 3522,122,55
+State Senate,,Jeanine Calkin*,D,Warwick 3523,192,111
+State Senate,,Jeanine Calkin*,D,Warwick 3524,119,61
+State Senate,,Jeanine Calkin*,D,Warwick 3525,175,95
+State Senate,,Jeanine Calkin*,D,Warwick 3526,46,33
+State Senate,,Jeanine Calkin*,D,Warwick 3527,181,103
+State Senate,,Mark P. McKenney,D,Warwick 3506,41,22
+State Senate,,Mark P. McKenney,D,Warwick 3507,36,15
+State Senate,,Mark P. McKenney,D,Warwick 3518,207,97
+State Senate,,Mark P. McKenney,D,Warwick 3519,183,73
+State Senate,,Mark P. McKenney,D,Warwick 3520,109,49
+State Senate,,Mark P. McKenney,D,Warwick 3522,76,38
+State Senate,,Mark P. McKenney,D,Warwick 3523,231,118
+State Senate,,Mark P. McKenney,D,Warwick 3524,80,36
+State Senate,,Mark P. McKenney,D,Warwick 3525,109,67
+State Senate,,Mark P. McKenney,D,Warwick 3526,43,23
+State Senate,,Mark P. McKenney,D,Warwick 3527,102,48
+State Senate,,Steve Merolla*,D,Warwick 3504,80,47
+State Senate,,Steve Merolla*,D,Warwick 3505,31,12
+State Senate,,Steve Merolla*,D,Warwick 3508,60,30
+State Senate,,Steve Merolla*,D,Warwick 3509,29,21
+State Senate,,Steve Merolla*,D,Warwick 3510,34,15
+State Senate,,Steve Merolla*,D,Warwick 3511,71,42
+State Senate,,Steve Merolla*,D,Warwick 3528,29,19
+State Senate,,Steve Merolla*,D,Warwick 3529,78,56
+State Senate,,Steve Merolla*,D,Warwick 3530,149,72
+State Senate,,Steve Merolla*,D,Warwick 3531,173,82
+State Senate,,Steve Merolla*,D,Warwick 3532,49,27
+State Senate,,Steve Merolla*,D,Warwick 3533,69,41
+State Senate,,Kendra Anderson,D,Warwick 3504,229,109
+State Senate,,Kendra Anderson,D,Warwick 3505,68,32
+State Senate,,Kendra Anderson,D,Warwick 3508,148,46
+State Senate,,Kendra Anderson,D,Warwick 3509,16,10
+State Senate,,Kendra Anderson,D,Warwick 3510,90,53
+State Senate,,Kendra Anderson,D,Warwick 3511,77,52
+State Senate,,Kendra Anderson,D,Warwick 3528,38,19
+State Senate,,Kendra Anderson,D,Warwick 3529,81,58
+State Senate,,Kendra Anderson,D,Warwick 3530,82,45
+State Senate,,Kendra Anderson,D,Warwick 3531,129,80
+State Senate,,Kendra Anderson,D,Warwick 3532,23,7
+State Senate,,Kendra Anderson,D,Warwick 3533,35,16
+State Senate,,Brian S. Dunckley,D,Warwick 3504,102,43
+State Senate,,Brian S. Dunckley,D,Warwick 3505,16,3
+State Senate,,Brian S. Dunckley,D,Warwick 3508,81,29
+State Senate,,Brian S. Dunckley,D,Warwick 3509,21,16
+State Senate,,Brian S. Dunckley,D,Warwick 3510,74,23
+State Senate,,Brian S. Dunckley,D,Warwick 3511,136,59
+State Senate,,Brian S. Dunckley,D,Warwick 3528,30,9
+State Senate,,Brian S. Dunckley,D,Warwick 3529,82,30
+State Senate,,Brian S. Dunckley,D,Warwick 3530,89,38
+State Senate,,Brian S. Dunckley,D,Warwick 3531,85,42
+State Senate,,Brian S. Dunckley,D,Warwick 3532,26,10
+State Senate,,Brian S. Dunckley,D,Warwick 3533,29,15
+State Senate,,Michael F. Mita,D,Warwick 3504,43,26
+State Senate,,Michael F. Mita,D,Warwick 3505,16,7
+State Senate,,Michael F. Mita,D,Warwick 3508,14,2
+State Senate,,Michael F. Mita,D,Warwick 3509,12,2
+State Senate,,Michael F. Mita,D,Warwick 3510,54,18
+State Senate,,Michael F. Mita,D,Warwick 3511,46,18
+State Senate,,Michael F. Mita,D,Warwick 3528,56,27
+State Senate,,Michael F. Mita,D,Warwick 3529,69,30
+State Senate,,Michael F. Mita,D,Warwick 3530,132,47
+State Senate,,Michael F. Mita,D,Warwick 3531,168,49
+State Senate,,Michael F. Mita,D,Warwick 3532,19,11
+State Senate,,Michael F. Mita,D,Warwick 3533,24,5
+State Senate,,Cynthia Armour Coyne*,D,Bristol 0203,383,226
+State Senate,,Cynthia Armour Coyne*,D,Bristol 0204,182,93
+State Senate,,Cynthia Armour Coyne*,D,Bristol 0209,23,8
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0601,65,21
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0602,22,5
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0603,111,56
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0604,138,56
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0609,89,36
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0610,59,27
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0611,92,45
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0613,125,65
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0615,254,134
+State Senate,,Leonidas P. Raptakis*,D,Coventry 0618,35,22
+State Senate,,Leonidas P. Raptakis*,D,East Greenwich 0901,48,24
+State Senate,,Leonidas P. Raptakis*,D,West Greenwich 3702,62,26
+State Senate,,Leonidas P. Raptakis*,D,West Greenwich 3704,47,28
+State Senate,,Jennifer C. Douglas,D,Charlestown 0501,144,59
+State Senate,,Jennifer C. Douglas,D,Charlestown 0502,141,66
+State Senate,,Jennifer C. Douglas,D,Exeter 1101,89,47
+State Senate,,Jennifer C. Douglas,D,Exeter 1103,202,116
+State Senate,,Jennifer C. Douglas,D,Hopkinton 1401,238,113
+State Senate,,Jennifer C. Douglas,D,Hopkinton 1402,162,91
+State Senate,,Jennifer C. Douglas,D,Hopkinton 1403,57,34
+State Senate,,Jennifer C. Douglas,D,Richmond 2902,356,181
+State Senate,,Jennifer C. Douglas,D,West Greenwich 3703,41,20
+State Senate,,Bridget G. Valverde*,D,East Greenwich 0903,423,217
+State Senate,,Bridget G. Valverde*,D,East Greenwich 0905,345,203
+State Senate,,Bridget G. Valverde*,D,Narragansett 2001,60,32
+State Senate,,Bridget G. Valverde*,D,Narragansett 2004,468,275
+State Senate,,Bridget G. Valverde*,D,Narragansett 2005,355,221
+State Senate,,Bridget G. Valverde*,D,North Kingstown 2301,186,106
+State Senate,,Bridget G. Valverde*,D,North Kingstown 2306,266,151
+State Senate,,Bridget G. Valverde*,D,South Kingstown 3201,119,54
+State Senate,,Alana DiMario*,D,Narragansett 2002,424,236
+State Senate,,Alana DiMario*,D,Narragansett 2003,384,212
+State Senate,,Alana DiMario*,D,North Kingstown 2304,649,348
+State Senate,,Alana DiMario*,D,North Kingstown 2309,1042,616
+State Senate,,Ellen S. Waxman,D,Narragansett 2002,80,33
+State Senate,,Ellen S. Waxman,D,Narragansett 2003,69,24
+State Senate,,Ellen S. Waxman,D,North Kingstown 2304,283,130
+State Senate,,Ellen S. Waxman,D,North Kingstown 2309,392,200
+State Senate,,Virginia S. Sosnowski*,D,New Shoreham 2201,138,67
+State Senate,,Virginia S. Sosnowski*,D,South Kingstown 3202,638,403
+State Senate,,Virginia S. Sosnowski*,D,South Kingstown 3204,613,329
+State Senate,,Virginia S. Sosnowski*,D,South Kingstown 3207,1000,621
+State Senate,,Virginia S. Sosnowski*,D,South Kingstown 3209,133,73
+State Senate,,Maggie A. Kain,D,New Shoreham 2201,80,27
+State Senate,,Maggie A. Kain,D,South Kingstown 3202,320,165
+State Senate,,Maggie A. Kain,D,South Kingstown 3204,571,268
+State Senate,,Maggie A. Kain,D,South Kingstown 3207,580,326
+State Senate,,Maggie A. Kain,D,South Kingstown 3209,92,45
+State House,,Edith H. Ajello*,D,Providence 2801,31,5
+State House,,Edith H. Ajello*,D,Providence 2807,0,0
+State House,,Edith H. Ajello*,D,Providence 2835,63,48
+State House,,Edith H. Ajello*,D,Providence 2836,3,2
+State House,,Christopher R. Blazejewski*,D,Providence 2810,26,17
+State House,,Christopher R. Blazejewski*,D,Providence 2837,140,63
+State House,,Christopher R. Blazejewski*,D,Providence 2838,73,23
+State House,,Christopher R. Blazejewski*,D,Providence 2839,186,50
+State House,,Moira J. Walsh,D,Providence 2811,226,96
+State House,,Moira J. Walsh,D,Providence 2841,41,12
+State House,,Nathan W. Biah,D,Providence 2811,469,112
+State House,,Nathan W. Biah,D,Providence 2841,22,5
+State House,,Rebecca M. Kislak*,D,Providence 2818,637,244
+State House,,Marcia P. Ranglin-Vassell,D,Providence 2819,252,102
+State House,,Marcia P. Ranglin-Vassell,D,Providence 2820,221,57
+State House,,Marcia P. Ranglin-Vassell,D,Providence 2842,35,10
+State House,,Marcia P. Ranglin-Vassell,D,Providence 2844,287,96
+State House,,Raymond A. Hull*,D,North Providence 2401,230,62
+State House,,Raymond A. Hull*,D,Providence 2846,371,110
+State House,,Raymond A. Hull*,D,Providence 2847,71,4
+State House,,Raymond A. Hull*,D,Providence 2850,309,96
+State House,,Angel Subervi*,D,Providence 2853,100,33
+State House,,Angel Subervi*,D,Providence 2854,303,64
+State House,,Daniel P. McKiernan,D,Providence 2853,173,81
+State House,,Daniel P. McKiernan,D,Providence 2854,320,94
+State House,,David Morales,D,Providence 2853,243,96
+State House,,David Morales,D,Providence 2854,632,212
+State House,,John J. Lombardi*,D,Providence 2859,117,31
+State House,,John J. Lombardi*,D,Providence 2863,981,410
+State House,,Darwin Castro,D,Providence 2859,28,5
+State House,,Darwin Castro,D,Providence 2863,93,33
+State House,,Anastasia P. Williams*,D,Providence 2822,31,11
+State House,,Anastasia P. Williams*,D,Providence 2864,55,17
+State House,,Anastasia P. Williams*,D,Providence 2867,337,140
+State House,,Anastasia P. Williams*,D,Providence 2868,192,54
+State House,,Anastasia P. Williams*,D,Providence 2869,97,16
+State House,,Scott A. Slater,D,Providence 2871,130,22
+State House,,Grace Diaz*,D,Providence 2826,500,198
+State House,,Grace Diaz*,D,Providence 2830,230,81
+State House,,Laura Perez,D,Providence 2826,169,44
+State House,,Laura Perez,D,Providence 2830,107,35
+State House,,Carlos Cedeno,D,Providence 2831,433,161
+State House,,Carlos Cedeno,D,Providence 2834,24,10
+State House,,Jose F. Batista,D,Providence 2831,556,268
+State House,,Jose F. Batista,D,Providence 2834,33,16
+State House,,Mario F. Mendez*,D,Johnston 1601,89,35
+State House,,Mario F. Mendez*,D,Providence 2875,151,48
+State House,,Ramon A. Perez,D,Johnston 1601,137,87
+State House,,Ramon A. Perez,D,Providence 2875,624,492
+State House,,Janice A. Falconer,D,Johnston 1601,24,3
+State House,,Janice A. Falconer,D,Providence 2875,111,23
+State House,,Charlene Lima*,D,Cranston 0701,216,104
+State House,,Charlene Lima*,D,Cranston 0702,153,43
+State House,,Charlene Lima*,D,Cranston 0703,148,87
+State House,,Charlene Lima*,D,Cranston 0704,60,26
+State House,,Charlene Lima*,D,Cranston 0705,47,18
+State House,,Charlene Lima*,D,Providence 2877,48,10
+State House,,Nicholas A. Mattiello*,D,Cranston 0706,176,72
+State House,,Nicholas A. Mattiello*,D,Cranston 0707,195,107
+State House,,Nicholas A. Mattiello*,D,Cranston 0708,236,109
+State House,,Nicholas A. Mattiello*,D,Cranston 0709,212,98
+State House,,Christopher T. Millea*,D,Cranston 0710,115,53
+State House,,Christopher T. Millea*,D,Cranston 0711,104,46
+State House,,Christopher T. Millea*,D,Cranston 0712,194,88
+State House,,Christopher T. Millea*,D,Cranston 0713,154,79
+State House,,Christopher T. Millea*,D,Cranston 0714,18,7
+State House,,Christopher T. Millea*,D,Cranston 0715,90,37
+State House,,Brandon C. Potter,D,Cranston 0710,279,120
+State House,,Brandon C. Potter,D,Cranston 0711,171,75
+State House,,Brandon C. Potter,D,Cranston 0712,156,97
+State House,,Brandon C. Potter,D,Cranston 0713,178,88
+State House,,Brandon C. Potter,D,Cranston 0714,54,24
+State House,,Brandon C. Potter,D,Cranston 0715,166,69
+State House,,Jacquelyn M. Baginski,D,Cranston 0716,154,86
+State House,,Jacquelyn M. Baginski,D,Cranston 0717,109,52
+State House,,Jacquelyn M. Baginski,D,Cranston 0718,108,45
+State House,,Jacquelyn M. Baginski,D,Cranston 0719,182,100
+State House,,Jacquelyn M. Baginski,D,Cranston 0720,84,35
+State House,,Jacquelyn M. Baginski,D,Cranston 0721,298,125
+State House,,Jacquelyn M. Baginski,D,Cranston 0722,122,37
+State House,,Arthur Handy*,D,Cranston 0723,563,249
+State House,,Arthur Handy*,D,Cranston 0724,557,290
+State House,,Arthur Handy*,D,Cranston 0725,465,221
+State House,,Arthur Handy*,D,Cranston 0726,195,76
+State House,,Joseph McNamara*,D,Cranston 0727,191,96
+State House,,Joseph McNamara*,D,Warwick 3501,410,222
+State House,,Joseph McNamara*,D,Warwick 3502,321,147
+State House,,Joseph McNamara*,D,Warwick 3503,124,64
+State House,,Joseph McNamara*,D,Warwick 3504,292,147
+State House,,Joseph McNamara*,D,Warwick 3505,83,33
+State House,,Stuart A. Wilson,D,Cranston 0727,132,62
+State House,,Stuart A. Wilson,D,Warwick 3501,228,114
+State House,,Stuart A. Wilson,D,Warwick 3502,199,80
+State House,,Stuart A. Wilson,D,Warwick 3503,84,36
+State House,,Stuart A. Wilson,D,Warwick 3504,164,78
+State House,,Stuart A. Wilson,D,Warwick 3505,49,20
+State House,,David A. Bennett*,D,Cranston 0728,4,4
+State House,,David A. Bennett*,D,Warwick 3506,99,57
+State House,,David A. Bennett*,D,Warwick 3507,57,26
+State House,,David A. Bennett*,D,Warwick 3508,264,105
+State House,,David A. Bennett*,D,Warwick 3509,70,43
+State House,,David A. Bennett*,D,Warwick 3510,204,93
+State House,,David A. Bennett*,D,Warwick 3511,271,152
+State House,,Camille F. Vella-Wilkinson*,D,Warwick 3512,185,83
+State House,,Camille F. Vella-Wilkinson*,D,Warwick 3513,292,161
+State House,,Camille F. Vella-Wilkinson*,D,Warwick 3514,348,168
+State House,,Camille F. Vella-Wilkinson*,D,Warwick 3515,389,165
+State House,,"Joseph J. Solomon, Jr.*",D,Warwick 3516,85,38
+State House,,"Joseph J. Solomon, Jr.*",D,Warwick 3517,90,47
+State House,,"Joseph J. Solomon, Jr.*",D,Warwick 3518,303,163
+State House,,"Joseph J. Solomon, Jr.*",D,Warwick 3519,314,147
+State House,,"Joseph J. Solomon, Jr.*",D,Warwick 3520,230,123
+State House,,K. Joseph Shekarchi*,D,Warwick 3521,189,110
+State House,,K. Joseph Shekarchi*,D,Warwick 3522,164,81
+State House,,K. Joseph Shekarchi*,D,Warwick 3523,332,184
+State House,,K. Joseph Shekarchi*,D,Warwick 3524,172,90
+State House,,K. Joseph Shekarchi*,D,Warwick 3525,246,148
+State House,,Evan P. Shanley,D,Warwick 3526,81,54
+State House,,Evan P. Shanley,D,Warwick 3527,257,142
+State House,,Evan P. Shanley,D,Warwick 3528,135,68
+State House,,Evan P. Shanley,D,Warwick 3529,267,155
+State House,,Evan P. Shanley,D,Warwick 3530,388,180
+State House,,Evan P. Shanley,D,Warwick 3531,463,228
+State House,,Thomas E. Noret*,D,Coventry 0601,72,23
+State House,,Thomas E. Noret*,D,Coventry 0602,21,5
+State House,,Thomas E. Noret*,D,West Warwick 3801,196,93
+State House,,Thomas E. Noret*,D,West Warwick 3802,95,40
+State House,,Thomas E. Noret*,D,West Warwick 3803,81,28
+State House,,Thomas E. Noret*,D,West Warwick 3810,163,66
+State House,,James B. Jackson*,D,Coventry 0603,117,49
+State House,,James B. Jackson*,D,Warwick 3532,84,43
+State House,,James B. Jackson*,D,West Warwick 3804,395,202
+State House,,James B. Jackson*,D,West Warwick 3805,105,50
+State House,,James B. Jackson*,D,West Warwick 3806,84,33
+State House,,Patricia A. Serpa*,D,Coventry 0604,109,35
+State House,,Patricia A. Serpa*,D,Warwick 3533,89,48
+State House,,Patricia A. Serpa*,D,West Warwick 3807,267,136
+State House,,Patricia A. Serpa*,D,West Warwick 3808,234,105
+State House,,Patricia A. Serpa*,D,West Warwick 3809,232,133
+State House,,Nicholas E. Delmenico,D,Coventry 0604,46,25
+State House,,Nicholas E. Delmenico,D,Warwick 3533,70,31
+State House,,Nicholas E. Delmenico,D,West Warwick 3807,91,44
+State House,,Nicholas E. Delmenico,D,West Warwick 3808,118,42
+State House,,Nicholas E. Delmenico,D,West Warwick 3809,69,42
+State House,,Scott J. Guthrie*,D,Coventry 0605,70,26
+State House,,Scott J. Guthrie*,D,Coventry 0606,264,111
+State House,,Scott J. Guthrie*,D,Coventry 0609,90,37
+State House,,Scott J. Guthrie*,D,Coventry 0610,57,26
+State House,,Scott J. Guthrie*,D,Coventry 0611,83,38
+State House,,Justine A. Caldwell*,D,East Greenwich 0901,55,26
+State House,,Justine A. Caldwell*,D,East Greenwich 0903,426,221
+State House,,Justine A. Caldwell*,D,East Greenwich 0905,346,204
+State House,,Justine A. Caldwell*,D,West Greenwich 3704,51,27
+State House,,Julie A. Casimiro*,D,Exeter 1101,94,50
+State House,,Julie A. Casimiro*,D,North Kingstown 2301,195,109
+State House,,Julie A. Casimiro*,D,North Kingstown 2304,836,449
+State House,,Robert E. Craven*,D,North Kingstown 2306,268,151
+State House,,Robert E. Craven*,D,North Kingstown 2309,1258,725
+State House,,Carol Hagan McEntee*,D,Narragansett 2001,62,32
+State House,,Carol Hagan McEntee*,D,Narragansett 2002,445,249
+State House,,Carol Hagan McEntee*,D,Narragansett 2003,403,218
+State House,,Carol Hagan McEntee*,D,South Kingstown 3201,129,57
+State House,,Carol Hagan McEntee*,D,South Kingstown 3202,778,497
+State House,,Teresa A. Tanzi*,D,Narragansett 2004,420,252
+State House,,Teresa A. Tanzi*,D,Narragansett 2005,293,192
+State House,,Teresa A. Tanzi*,D,South Kingstown 3204,861,459
+State House,,Gina M. Giramma,D,Narragansett 2004,162,67
+State House,,Gina M. Giramma,D,Narragansett 2005,169,77
+State House,,Gina M. Giramma,D,South Kingstown 3204,312,133
+State House,,Kathleen A. Fogarty*,D,South Kingstown 3207,1182,762
+State House,,Spencer E. Dickinson,D,South Kingstown 3207,379,171
+State House,,Samuel A. Azzinaro*,D,Westerly 3602,146,89
+State House,,Samuel A. Azzinaro*,D,Westerly 3603,180,115
+State House,,Samuel A. Azzinaro*,D,Westerly 3604,142,90
+State House,,Samuel A. Azzinaro*,D,Westerly 3605,152,95
+State House,,Brian Patrick Kennedy*,D,Hopkinton 1401,193,84
+State House,,Brian Patrick Kennedy*,D,Hopkinton 1402,102,65
+State House,,Brian Patrick Kennedy*,D,Westerly 3606,121,74
+State House,,Brian Patrick Kennedy*,D,Westerly 3607,103,56
+State House,,Miguel J. Torres,D,Hopkinton 1401,86,46
+State House,,Miguel J. Torres,D,Hopkinton 1402,80,33
+State House,,Miguel J. Torres,D,Westerly 3606,73,34
+State House,,Miguel J. Torres,D,Westerly 3607,39,16
+State House,,Megan L. Cotter*,D,Exeter 1103,207,118
+State House,,Megan L. Cotter*,D,Hopkinton 1403,57,34
+State House,,Megan L. Cotter*,D,Richmond 2902,363,190
+State House,,Linda A. Nichols,D,Coventry 0617,60,33
+State House,,Linda A. Nichols,D,Coventry 0618,33,20
+State House,,Linda A. Nichols,D,Foster 1201,193,122
+State House,,Linda A. Nichols,D,Glocester 1301,255,137
+State House,,Pamela Carosi*,D,Cranston 0730,191,97
+State House,,Pamela Carosi*,D,Scituate 3001,133,66
+State House,,Pamela Carosi*,D,Scituate 3002,97,49
+State House,,Pamela Carosi*,D,Scituate 3003,128,64
+State House,,Giuseppe Mattiello,D,Cranston 0730,77,19
+State House,,Giuseppe Mattiello,D,Scituate 3001,31,12
+State House,,Giuseppe Mattiello,D,Scituate 3002,15,5
+State House,,Giuseppe Mattiello,D,Scituate 3003,15,7
+State House,,"Edward T. Cardillo, Jr.*",D,Cranston 0731,231,97
+State House,,"Edward T. Cardillo, Jr.*",D,Johnston 1603,263,120
+State House,,"Edward T. Cardillo, Jr.*",D,Johnston 1604,118,44
+State House,,"Edward T. Cardillo, Jr.*",D,Johnston 1605,96,36
+State House,,Deborah A. Fellela*,D,Johnston 1606,39,14
+State House,,Deborah A. Fellela*,D,Johnston 1607,48,21
+State House,,Deborah A. Fellela*,D,Johnston 1608,148,43
+State House,,Deborah A. Fellela*,D,Johnston 1609,188,78
+State House,,Deborah A. Fellela*,D,Johnston 1610,283,111
+State House,,Deborah A. Fellela*,D,Johnston 1611,170,75
+State House,,Deborah A. Fellela*,D,Johnston 1612,137,51
+State House,,Melinda Lopez,D,Johnston 1606,28,13
+State House,,Melinda Lopez,D,Johnston 1607,36,20
+State House,,Melinda Lopez,D,Johnston 1608,78,23
+State House,,Melinda Lopez,D,Johnston 1609,68,30
+State House,,Melinda Lopez,D,Johnston 1610,231,95
+State House,,Melinda Lopez,D,Johnston 1611,81,30
+State House,,Melinda Lopez,D,Johnston 1612,72,25
+State House,,Gregory J. Costantino*,D,Johnston 1613,122,50
+State House,,Gregory J. Costantino*,D,Smithfield 3101,252,108
+State House,,Gregory J. Costantino*,D,Smithfield 3103,429,196
+State House,,Mia A. Ackerman*,D,Cumberland 0801,131,57
+State House,,Mia A. Ackerman*,D,Cumberland 0802,250,109
+State House,,Mia A. Ackerman*,D,Cumberland 0803,165,91
+State House,,Mary Ann Shallcross Smith,D,Pawtucket 2601,64,19
+State House,,Steven J. Lima,D,Woonsocket 3901,13,6
+State House,,Stephen M. Casey*,D,Woonsocket 3905,89,28
+State House,,Stephen M. Casey*,D,Woonsocket 3907,267,111
+State House,,Robert D. Phillips,D,Cumberland 0804,29,17
+State House,,Robert D. Phillips,D,Woonsocket 3910,263,104
+State House,,Alex D. Marszalkowski*,D,Cumberland 0809,68,39
+State House,,Bernard A. Hawkins*,D,Glocester 1304,82,43
+State House,,Bernard A. Hawkins*,D,Smithfield 3104,208,102
+State House,,Bernard A. Hawkins*,D,Smithfield 3105,420,222
+State House,,William W. O'Brien*,D,North Providence 2403,383,161
+State House,,William W. O'Brien*,D,North Providence 2405,161,68
+State House,,William W. O'Brien*,D,North Providence 2407,417,116
+State House,,William W. O'Brien*,D,North Providence 2409,76,32
+State House,,Arthur J. Corvese*,D,North Providence 2410,238,97
+State House,,Arthur J. Corvese*,D,North Providence 2412,819,282
+State House,,Arthur J. Corvese*,D,North Providence 2414,125,33
+State House,,Arthur J. Corvese*,D,North Providence 2415,181,55
+State House,,Arthur J. Corvese*,D,North Providence 2416,405,161
+State House,,Joshua J. Giraldo*,D,Central Falls 0401,174,41
+State House,,Joshua J. Giraldo*,D,Central Falls 0402,78,17
+State House,,Joshua J. Giraldo*,D,Central Falls 0403,245,122
+State House,,Joshua J. Giraldo*,D,Central Falls 0404,203,76
+State House,,Joshua J. Giraldo*,D,Central Falls 0405,80,37
+State House,,James N. McLaughlin*,D,Central Falls 0406,115,36
+State House,,James N. McLaughlin*,D,Central Falls 0407,45,7
+State House,,James N. McLaughlin*,D,Central Falls 0408,160,42
+State House,,James N. McLaughlin*,D,Cumberland 0812,193,99
+State House,,Carlos Eduardo Tobon,D,Pawtucket 2602,132,33
+State House,,Carlos Eduardo Tobon,D,Pawtucket 2603,324,140
+State House,,Carlos Eduardo Tobon,D,Pawtucket 2604,169,77
+State House,,Carlos Eduardo Tobon,D,Pawtucket 2605,86,29
+State House,,Carlos Eduardo Tobon,D,Pawtucket 2606,96,33
+State House,,Jean Philippe Barros*,D,Pawtucket 2607,575,316
+State House,,Jean Philippe Barros*,D,Pawtucket 2608,491,304
+State House,,Jean Philippe Barros*,D,Pawtucket 2609,46,24
+State House,,Jean Philippe Barros*,D,Pawtucket 2610,25,9
+State House,,Jean Philippe Barros*,D,Pawtucket 2611,119,59
+State House,,Jean Philippe Barros*,D,Pawtucket 2631,125,47
+State House,,Karen Alzate*,D,Pawtucket 2612,150,69
+State House,,Karen Alzate*,D,Pawtucket 2613,198,113
+State House,,Karen Alzate*,D,Pawtucket 2614,153,68
+State House,,Karen Alzate*,D,Pawtucket 2615,106,38
+State House,,Karen Alzate*,D,Pawtucket 2616,47,21
+State House,,Karen Alzate*,D,Pawtucket 2617,46,14
+State House,,"Raymond H. Johnston, Jr.*",D,Pawtucket 2618,290,130
+State House,,"Raymond H. Johnston, Jr.*",D,Pawtucket 2619,119,54
+State House,,"Raymond H. Johnston, Jr.*",D,Pawtucket 2620,154,80
+State House,,"Raymond H. Johnston, Jr.*",D,Pawtucket 2621,68,29
+State House,,"Raymond H. Johnston, Jr.*",D,Pawtucket 2622,31,15
+State House,,"Raymond H. Johnston, Jr.*",D,Pawtucket 2623,35,12
+State House,,Leonela Felix,D,Pawtucket 2618,280,108
+State House,,Leonela Felix,D,Pawtucket 2619,173,48
+State House,,Leonela Felix,D,Pawtucket 2620,329,132
+State House,,Leonela Felix,D,Pawtucket 2621,77,20
+State House,,Leonela Felix,D,Pawtucket 2622,53,21
+State House,,Leonela Felix,D,Pawtucket 2623,76,26
+State House,,Mary Duffy Messier*,D,Pawtucket 2624,137,60
+State House,,Mary Duffy Messier*,D,Pawtucket 2625,71,25
+State House,,Mary Duffy Messier*,D,Pawtucket 2626,29,12
+State House,,Mary Duffy Messier*,D,Pawtucket 2627,207,91
+State House,,Mary Duffy Messier*,D,Pawtucket 2628,291,163
+State House,,Mary Duffy Messier*,D,Pawtucket 2629,343,187
+State House,,Mary Duffy Messier*,D,Pawtucket 2630,28,9
+State House,,Katherine S. Kazarian*,D,East Providence 1003,92,30
+State House,,Katherine S. Kazarian*,D,East Providence 1005,625,335
+State House,,Katherine S. Kazarian*,D,East Providence 1006,15,7
+State House,,Katherine S. Kazarian*,D,East Providence 1007,19,6
+State House,,Jose R. Serodio*,D,East Providence 1009,318,159
+State House,,Jose R. Serodio*,D,East Providence 1010,135,64
+State House,,Brianna E. Henries,D,East Providence 1009,426,176
+State House,,Brianna E. Henries,D,East Providence 1010,301,147
+State House,,Gregg Amore*,D,East Providence 1012,141,56
+State House,,Gregg Amore*,D,East Providence 1013,484,226
+State House,,Liana M. Cassar*,D,East Providence 1016,146,70
+State House,,June S. Speakman*,D,Bristol 0201,96,50
+State House,,June S. Speakman*,D,Bristol 0202,114,57
+State House,,June S. Speakman*,D,Bristol 0203,392,239
+State House,,June S. Speakman*,D,Bristol 0204,181,96
+State House,,Susan R. Donovan*,D,Bristol 0205,143,54
+State House,,Susan R. Donovan*,D,Bristol 0206,146,55
+State House,,Susan R. Donovan*,D,Bristol 0207,172,108
+State House,,Susan R. Donovan*,D,Bristol 0208,143,84
+State House,,Susan R. Donovan*,D,Bristol 0209,25,9
+State House,,"John G. Edwards, V*",D,Little Compton 1801,63,27
+State House,,"John G. Edwards, V*",D,Portsmouth 2704,115,56
+State House,,"John G. Edwards, V*",D,Tiverton 3306,133,56
+State House,,Michelle E. McGaw,D,Little Compton 1801,496,207
+State House,,Michelle E. McGaw,D,Portsmouth 2704,419,232
+State House,,Michelle E. McGaw,D,Tiverton 3306,319,171
+State House,,Terri-Denise Cortvriend*,D,Middletown 1902,377,185
+State House,,Terri-Denise Cortvriend*,D,Portsmouth 2708,818,509
+State House,,Christopher T. Semonelli,D,Middletown 1902,160,83
+State House,,Christopher T. Semonelli,D,Portsmouth 2708,126,56
+State House,,Deborah L. Ruggiero*,D,Jamestown 1501,1136,742
+State House,,Deborah L. Ruggiero*,D,Middletown 1904,436,297
+State House,,"Henry F. Lombardi, Jr.",D,Jamestown 1501,98,31
+State House,,"Henry F. Lombardi, Jr.",D,Middletown 1904,148,72
+U.S. Senate,,Allen R. Waters,R,Burrillville 0301,92,15
+U.S. Senate,,Allen R. Waters,R,Burrillville 0303,130,20
+U.S. Senate,,Allen R. Waters,R,Burrillville 0306,40,7
+U.S. Senate,,Allen R. Waters,R,Burrillville Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Charlestown 0501,37,1
+U.S. Senate,,Allen R. Waters,R,Charlestown 0502,40,3
+U.S. Senate,,Allen R. Waters,R,Charlestown 0503,50,4
+U.S. Senate,,Allen R. Waters,R,Charlestown 0504,37,10
+U.S. Senate,,Allen R. Waters,R,Charlestown Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Coventry 0601,38,1
+U.S. Senate,,Allen R. Waters,R,Coventry 0602,9,0
+U.S. Senate,,Allen R. Waters,R,Coventry 0603,70,12
+U.S. Senate,,Allen R. Waters,R,Coventry 0604,25,2
+U.S. Senate,,Allen R. Waters,R,Coventry 0605,29,6
+U.S. Senate,,Allen R. Waters,R,Coventry 0606,94,6
+U.S. Senate,,Allen R. Waters,R,Coventry 0609,33,5
+U.S. Senate,,Allen R. Waters,R,Coventry 0610,28,0
+U.S. Senate,,Allen R. Waters,R,Coventry 0611,32,2
+U.S. Senate,,Allen R. Waters,R,Coventry 0613,56,7
+U.S. Senate,,Allen R. Waters,R,Coventry 0615,90,22
+U.S. Senate,,Allen R. Waters,R,Coventry 0617,29,3
+U.S. Senate,,Allen R. Waters,R,Coventry 0618,24,6
+U.S. Senate,,Allen R. Waters,R,Coventry Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Cranston 0701,65,4
+U.S. Senate,,Allen R. Waters,R,Cranston 0702,52,8
+U.S. Senate,,Allen R. Waters,R,Cranston 0703,77,4
+U.S. Senate,,Allen R. Waters,R,Cranston 0704,18,1
+U.S. Senate,,Allen R. Waters,R,Cranston 0705,32,5
+U.S. Senate,,Allen R. Waters,R,Cranston 0706,207,29
+U.S. Senate,,Allen R. Waters,R,Cranston 0707,204,16
+U.S. Senate,,Allen R. Waters,R,Cranston 0708,189,35
+U.S. Senate,,Allen R. Waters,R,Cranston 0709,255,29
+U.S. Senate,,Allen R. Waters,R,Cranston 0710,112,17
+U.S. Senate,,Allen R. Waters,R,Cranston 0711,124,14
+U.S. Senate,,Allen R. Waters,R,Cranston 0712,174,24
+U.S. Senate,,Allen R. Waters,R,Cranston 0713,198,23
+U.S. Senate,,Allen R. Waters,R,Cranston 0714,20,1
+U.S. Senate,,Allen R. Waters,R,Cranston 0715,95,9
+U.S. Senate,,Allen R. Waters,R,Cranston 0716,137,9
+U.S. Senate,,Allen R. Waters,R,Cranston 0717,40,5
+U.S. Senate,,Allen R. Waters,R,Cranston 0718,72,6
+U.S. Senate,,Allen R. Waters,R,Cranston 0719,117,8
+U.S. Senate,,Allen R. Waters,R,Cranston 0720,45,9
+U.S. Senate,,Allen R. Waters,R,Cranston 0721,88,6
+U.S. Senate,,Allen R. Waters,R,Cranston 0722,52,2
+U.S. Senate,,Allen R. Waters,R,Cranston 0723,58,5
+U.S. Senate,,Allen R. Waters,R,Cranston 0724,60,12
+U.S. Senate,,Allen R. Waters,R,Cranston 0725,107,8
+U.S. Senate,,Allen R. Waters,R,Cranston 0726,73,6
+U.S. Senate,,Allen R. Waters,R,Cranston 0727,49,2
+U.S. Senate,,Allen R. Waters,R,Cranston 0728,0,0
+U.S. Senate,,Allen R. Waters,R,Cranston 0730,306,31
+U.S. Senate,,Allen R. Waters,R,Cranston 0731,147,11
+U.S. Senate,,Allen R. Waters,R,Cranston Limited,0,0
+U.S. Senate,,Allen R. Waters,R,East Greenwich 0901,11,1
+U.S. Senate,,Allen R. Waters,R,East Greenwich 0903,81,24
+U.S. Senate,,Allen R. Waters,R,East Greenwich 0905,83,18
+U.S. Senate,,Allen R. Waters,R,East Greenwich Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Exeter 1101,34,5
+U.S. Senate,,Allen R. Waters,R,Exeter 1103,83,12
+U.S. Senate,,Allen R. Waters,R,Exeter Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Foster 1201,88,8
+U.S. Senate,,Allen R. Waters,R,Foster Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Glocester 1301,124,12
+U.S. Senate,,Allen R. Waters,R,Glocester 1303,13,0
+U.S. Senate,,Allen R. Waters,R,Glocester 1304,38,3
+U.S. Senate,,Allen R. Waters,R,Glocester Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Hopkinton 1401,73,10
+U.S. Senate,,Allen R. Waters,R,Hopkinton 1402,53,6
+U.S. Senate,,Allen R. Waters,R,Hopkinton 1403,18,1
+U.S. Senate,,Allen R. Waters,R,Hopkinton Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Johnston 1601,27,1
+U.S. Senate,,Allen R. Waters,R,Johnston 1603,53,5
+U.S. Senate,,Allen R. Waters,R,Johnston 1604,37,6
+U.S. Senate,,Allen R. Waters,R,Johnston 1605,29,3
+U.S. Senate,,Allen R. Waters,R,Johnston 1606,10,1
+U.S. Senate,,Allen R. Waters,R,Johnston 1607,10,0
+U.S. Senate,,Allen R. Waters,R,Johnston 1608,47,8
+U.S. Senate,,Allen R. Waters,R,Johnston 1609,19,1
+U.S. Senate,,Allen R. Waters,R,Johnston 1610,46,4
+U.S. Senate,,Allen R. Waters,R,Johnston 1611,17,4
+U.S. Senate,,Allen R. Waters,R,Johnston 1612,26,4
+U.S. Senate,,Allen R. Waters,R,Johnston 1613,15,3
+U.S. Senate,,Allen R. Waters,R,Johnston Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Narragansett 2001,4,0
+U.S. Senate,,Allen R. Waters,R,Narragansett 2002,60,15
+U.S. Senate,,Allen R. Waters,R,Narragansett 2003,67,10
+U.S. Senate,,Allen R. Waters,R,Narragansett 2004,91,16
+U.S. Senate,,Allen R. Waters,R,Narragansett 2005,69,18
+U.S. Senate,,Allen R. Waters,R,Narragansett Limited,0,0
+U.S. Senate,,Allen R. Waters,R,New Shoreham 2201,19,3
+U.S. Senate,,Allen R. Waters,R,New Shoreham Limited,0,0
+U.S. Senate,,Allen R. Waters,R,North Kingstown 2301,38,9
+U.S. Senate,,Allen R. Waters,R,North Kingstown 2304,179,38
+U.S. Senate,,Allen R. Waters,R,North Kingstown 2306,31,3
+U.S. Senate,,Allen R. Waters,R,North Kingstown 2309,179,46
+U.S. Senate,,Allen R. Waters,R,North Kingstown Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Providence 2835,11,4
+U.S. Senate,,Allen R. Waters,R,Providence 2836,0,0
+U.S. Senate,,Allen R. Waters,R,Providence 2837,3,1
+U.S. Senate,,Allen R. Waters,R,Providence 2838,3,0
+U.S. Senate,,Allen R. Waters,R,Providence 2839,6,1
+U.S. Senate,,Allen R. Waters,R,Providence 2841,3,1
+U.S. Senate,,Allen R. Waters,R,Providence 2842,1,1
+U.S. Senate,,Allen R. Waters,R,Providence 2844,15,1
+U.S. Senate,,Allen R. Waters,R,Providence 2846,21,1
+U.S. Senate,,Allen R. Waters,R,Providence 2847,4,0
+U.S. Senate,,Allen R. Waters,R,Providence 2850,21,2
+U.S. Senate,,Allen R. Waters,R,Providence 2853,11,2
+U.S. Senate,,Allen R. Waters,R,Providence 2854,24,2
+U.S. Senate,,Allen R. Waters,R,Providence 2859,1,0
+U.S. Senate,,Allen R. Waters,R,Providence 2863,20,1
+U.S. Senate,,Allen R. Waters,R,Providence 2864,3,0
+U.S. Senate,,Allen R. Waters,R,Providence 2867,2,0
+U.S. Senate,,Allen R. Waters,R,Providence 2868,3,0
+U.S. Senate,,Allen R. Waters,R,Providence 2869,7,0
+U.S. Senate,,Allen R. Waters,R,Providence 2871,7,0
+U.S. Senate,,Allen R. Waters,R,Providence 2875,36,2
+U.S. Senate,,Allen R. Waters,R,Providence 2877,5,1
+U.S. Senate,,Allen R. Waters,R,Providence Limited 2,0,0
+U.S. Senate,,Allen R. Waters,R,Richmond 2902,131,9
+U.S. Senate,,Allen R. Waters,R,Richmond Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Scituate 3001,70,12
+U.S. Senate,,Allen R. Waters,R,Scituate 3002,82,11
+U.S. Senate,,Allen R. Waters,R,Scituate 3003,68,11
+U.S. Senate,,Allen R. Waters,R,Scituate Limited,0,0
+U.S. Senate,,Allen R. Waters,R,South Kingstown 3201,12,3
+U.S. Senate,,Allen R. Waters,R,South Kingstown 3202,83,21
+U.S. Senate,,Allen R. Waters,R,South Kingstown 3204,54,7
+U.S. Senate,,Allen R. Waters,R,South Kingstown 3207,130,37
+U.S. Senate,,Allen R. Waters,R,South Kingstown 3209,20,4
+U.S. Senate,,Allen R. Waters,R,South Kingstown 3210,29,4
+U.S. Senate,,Allen R. Waters,R,South Kingstown Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Warwick 3501,56,5
+U.S. Senate,,Allen R. Waters,R,Warwick 3502,46,8
+U.S. Senate,,Allen R. Waters,R,Warwick 3503,19,2
+U.S. Senate,,Allen R. Waters,R,Warwick 3504,32,4
+U.S. Senate,,Allen R. Waters,R,Warwick 3505,16,5
+U.S. Senate,,Allen R. Waters,R,Warwick 3506,21,0
+U.S. Senate,,Allen R. Waters,R,Warwick 3507,15,2
+U.S. Senate,,Allen R. Waters,R,Warwick 3508,48,11
+U.S. Senate,,Allen R. Waters,R,Warwick 3509,8,3
+U.S. Senate,,Allen R. Waters,R,Warwick 3510,42,6
+U.S. Senate,,Allen R. Waters,R,Warwick 3511,46,10
+U.S. Senate,,Allen R. Waters,R,Warwick 3512,27,4
+U.S. Senate,,Allen R. Waters,R,Warwick 3513,51,18
+U.S. Senate,,Allen R. Waters,R,Warwick 3514,56,15
+U.S. Senate,,Allen R. Waters,R,Warwick 3515,69,11
+U.S. Senate,,Allen R. Waters,R,Warwick 3516,12,1
+U.S. Senate,,Allen R. Waters,R,Warwick 3517,13,1
+U.S. Senate,,Allen R. Waters,R,Warwick 3518,51,9
+U.S. Senate,,Allen R. Waters,R,Warwick 3519,83,10
+U.S. Senate,,Allen R. Waters,R,Warwick 3520,37,2
+U.S. Senate,,Allen R. Waters,R,Warwick 3521,43,5
+U.S. Senate,,Allen R. Waters,R,Warwick 3522,32,3
+U.S. Senate,,Allen R. Waters,R,Warwick 3523,46,11
+U.S. Senate,,Allen R. Waters,R,Warwick 3524,30,7
+U.S. Senate,,Allen R. Waters,R,Warwick 3525,36,4
+U.S. Senate,,Allen R. Waters,R,Warwick 3526,23,4
+U.S. Senate,,Allen R. Waters,R,Warwick 3527,26,4
+U.S. Senate,,Allen R. Waters,R,Warwick 3528,20,2
+U.S. Senate,,Allen R. Waters,R,Warwick 3529,50,8
+U.S. Senate,,Allen R. Waters,R,Warwick 3530,55,10
+U.S. Senate,,Allen R. Waters,R,Warwick 3531,69,10
+U.S. Senate,,Allen R. Waters,R,Warwick 3532,26,5
+U.S. Senate,,Allen R. Waters,R,Warwick 3533,20,7
+U.S. Senate,,Allen R. Waters,R,Warwick Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Westerly 3601,21,3
+U.S. Senate,,Allen R. Waters,R,Westerly 3602,33,8
+U.S. Senate,,Allen R. Waters,R,Westerly 3603,32,13
+U.S. Senate,,Allen R. Waters,R,Westerly 3604,35,13
+U.S. Senate,,Allen R. Waters,R,Westerly 3605,41,11
+U.S. Senate,,Allen R. Waters,R,Westerly 3606,21,5
+U.S. Senate,,Allen R. Waters,R,Westerly 3607,34,6
+U.S. Senate,,Allen R. Waters,R,Westerly Limited,0,0
+U.S. Senate,,Allen R. Waters,R,West Greenwich 3701,54,11
+U.S. Senate,,Allen R. Waters,R,West Greenwich 3702,34,8
+U.S. Senate,,Allen R. Waters,R,West Greenwich 3703,16,2
+U.S. Senate,,Allen R. Waters,R,West Greenwich 3704,34,9
+U.S. Senate,,Allen R. Waters,R,West Greenwich Limited,0,0
+U.S. Senate,,Allen R. Waters,R,West Warwick 3801,54,8
+U.S. Senate,,Allen R. Waters,R,West Warwick 3802,26,3
+U.S. Senate,,Allen R. Waters,R,West Warwick 3803,25,3
+U.S. Senate,,Allen R. Waters,R,West Warwick 3804,86,14
+U.S. Senate,,Allen R. Waters,R,West Warwick 3805,27,4
+U.S. Senate,,Allen R. Waters,R,West Warwick 3806,31,2
+U.S. Senate,,Allen R. Waters,R,West Warwick 3807,43,5
+U.S. Senate,,Allen R. Waters,R,West Warwick 3808,53,8
+U.S. Senate,,Allen R. Waters,R,West Warwick 3809,34,5
+U.S. Senate,,Allen R. Waters,R,West Warwick 3810,35,3
+U.S. Senate,,Allen R. Waters,R,West Warwick Limited,0,0
+U.S. Senate,,Allen R. Waters,R,Federal Precinct #2,11,4
+U.S. Senate,,Allen R. Waters,R,Federal Precinct #2S,1,1
+U.S. House,,Robert B. Lancia*,R,Burrillville 0301,62,12
+U.S. House,,Robert B. Lancia*,R,Burrillville 0303,84,12
+U.S. House,,Robert B. Lancia*,R,Burrillville 0306,29,4
+U.S. House,,Robert B. Lancia*,R,Burrillville Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Charlestown 0501,32,1
+U.S. House,,Robert B. Lancia*,R,Charlestown 0502,29,2
+U.S. House,,Robert B. Lancia*,R,Charlestown 0503,43,4
+U.S. House,,Robert B. Lancia*,R,Charlestown 0504,30,9
+U.S. House,,Robert B. Lancia*,R,Charlestown Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Coventry 0601,26,0
+U.S. House,,Robert B. Lancia*,R,Coventry 0602,5,0
+U.S. House,,Robert B. Lancia*,R,Coventry 0603,52,11
+U.S. House,,Robert B. Lancia*,R,Coventry 0604,22,2
+U.S. House,,Robert B. Lancia*,R,Coventry 0605,27,4
+U.S. House,,Robert B. Lancia*,R,Coventry 0606,73,6
+U.S. House,,Robert B. Lancia*,R,Coventry 0609,23,1
+U.S. House,,Robert B. Lancia*,R,Coventry 0610,21,0
+U.S. House,,Robert B. Lancia*,R,Coventry 0611,25,0
+U.S. House,,Robert B. Lancia*,R,Coventry 0613,38,8
+U.S. House,,Robert B. Lancia*,R,Coventry 0615,69,14
+U.S. House,,Robert B. Lancia*,R,Coventry 0617,29,1
+U.S. House,,Robert B. Lancia*,R,Coventry 0618,19,3
+U.S. House,,Robert B. Lancia*,R,Coventry Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Cranston 0701,48,4
+U.S. House,,Robert B. Lancia*,R,Cranston 0702,49,9
+U.S. House,,Robert B. Lancia*,R,Cranston 0703,81,4
+U.S. House,,Robert B. Lancia*,R,Cranston 0704,15,3
+U.S. House,,Robert B. Lancia*,R,Cranston 0705,24,5
+U.S. House,,Robert B. Lancia*,R,Cranston 0706,245,36
+U.S. House,,Robert B. Lancia*,R,Cranston 0707,215,18
+U.S. House,,Robert B. Lancia*,R,Cranston 0708,172,34
+U.S. House,,Robert B. Lancia*,R,Cranston 0709,263,33
+U.S. House,,Robert B. Lancia*,R,Cranston 0710,126,20
+U.S. House,,Robert B. Lancia*,R,Cranston 0711,121,18
+U.S. House,,Robert B. Lancia*,R,Cranston 0712,191,30
+U.S. House,,Robert B. Lancia*,R,Cranston 0713,232,31
+U.S. House,,Robert B. Lancia*,R,Cranston 0714,15,0
+U.S. House,,Robert B. Lancia*,R,Cranston 0715,93,14
+U.S. House,,Robert B. Lancia*,R,Cranston 0716,126,10
+U.S. House,,Robert B. Lancia*,R,Cranston 0717,32,4
+U.S. House,,Robert B. Lancia*,R,Cranston 0718,75,11
+U.S. House,,Robert B. Lancia*,R,Cranston 0719,122,6
+U.S. House,,Robert B. Lancia*,R,Cranston 0720,46,9
+U.S. House,,Robert B. Lancia*,R,Cranston 0721,81,11
+U.S. House,,Robert B. Lancia*,R,Cranston 0722,50,4
+U.S. House,,Robert B. Lancia*,R,Cranston 0723,51,5
+U.S. House,,Robert B. Lancia*,R,Cranston 0724,62,11
+U.S. House,,Robert B. Lancia*,R,Cranston 0725,95,10
+U.S. House,,Robert B. Lancia*,R,Cranston 0726,62,5
+U.S. House,,Robert B. Lancia*,R,Cranston 0727,43,2
+U.S. House,,Robert B. Lancia*,R,Cranston 0728,0,0
+U.S. House,,Robert B. Lancia*,R,Cranston 0730,303,33
+U.S. House,,Robert B. Lancia*,R,Cranston 0731,155,16
+U.S. House,,Robert B. Lancia*,R,Cranston Limited,0,0
+U.S. House,,Robert B. Lancia*,R,East Greenwich 0901,6,0
+U.S. House,,Robert B. Lancia*,R,East Greenwich 0903,67,17
+U.S. House,,Robert B. Lancia*,R,East Greenwich 0905,64,15
+U.S. House,,Robert B. Lancia*,R,East Greenwich Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Exeter 1101,31,6
+U.S. House,,Robert B. Lancia*,R,Exeter 1103,77,10
+U.S. House,,Robert B. Lancia*,R,Exeter Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Foster 1201,80,8
+U.S. House,,Robert B. Lancia*,R,Foster Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Glocester 1301,103,9
+U.S. House,,Robert B. Lancia*,R,Glocester 1303,11,0
+U.S. House,,Robert B. Lancia*,R,Glocester 1304,25,2
+U.S. House,,Robert B. Lancia*,R,Glocester Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Hopkinton 1401,62,9
+U.S. House,,Robert B. Lancia*,R,Hopkinton 1402,47,5
+U.S. House,,Robert B. Lancia*,R,Hopkinton 1403,15,1
+U.S. House,,Robert B. Lancia*,R,Hopkinton Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Johnston 1601,22,1
+U.S. House,,Robert B. Lancia*,R,Johnston 1603,47,4
+U.S. House,,Robert B. Lancia*,R,Johnston 1604,27,3
+U.S. House,,Robert B. Lancia*,R,Johnston 1605,24,2
+U.S. House,,Robert B. Lancia*,R,Johnston 1606,10,1
+U.S. House,,Robert B. Lancia*,R,Johnston 1607,11,0
+U.S. House,,Robert B. Lancia*,R,Johnston 1608,40,7
+U.S. House,,Robert B. Lancia*,R,Johnston 1609,12,1
+U.S. House,,Robert B. Lancia*,R,Johnston 1610,27,0
+U.S. House,,Robert B. Lancia*,R,Johnston 1611,6,2
+U.S. House,,Robert B. Lancia*,R,Johnston 1612,17,4
+U.S. House,,Robert B. Lancia*,R,Johnston 1613,12,2
+U.S. House,,Robert B. Lancia*,R,Johnston Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Narragansett 2001,6,1
+U.S. House,,Robert B. Lancia*,R,Narragansett 2002,43,8
+U.S. House,,Robert B. Lancia*,R,Narragansett 2003,51,7
+U.S. House,,Robert B. Lancia*,R,Narragansett 2004,62,12
+U.S. House,,Robert B. Lancia*,R,Narragansett 2005,61,16
+U.S. House,,Robert B. Lancia*,R,Narragansett Limited,0,0
+U.S. House,,Robert B. Lancia*,R,New Shoreham 2201,12,0
+U.S. House,,Robert B. Lancia*,R,New Shoreham Limited,0,0
+U.S. House,,Robert B. Lancia*,R,North Kingstown 2301,30,8
+U.S. House,,Robert B. Lancia*,R,North Kingstown 2304,132,27
+U.S. House,,Robert B. Lancia*,R,North Kingstown 2306,27,3
+U.S. House,,Robert B. Lancia*,R,North Kingstown 2309,123,34
+U.S. House,,Robert B. Lancia*,R,North Kingstown Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Providence 2835,10,4
+U.S. House,,Robert B. Lancia*,R,Providence 2836,0,0
+U.S. House,,Robert B. Lancia*,R,Providence 2837,2,1
+U.S. House,,Robert B. Lancia*,R,Providence 2838,3,0
+U.S. House,,Robert B. Lancia*,R,Providence 2839,4,1
+U.S. House,,Robert B. Lancia*,R,Providence 2841,3,1
+U.S. House,,Robert B. Lancia*,R,Providence 2842,0,0
+U.S. House,,Robert B. Lancia*,R,Providence 2844,10,1
+U.S. House,,Robert B. Lancia*,R,Providence 2846,17,1
+U.S. House,,Robert B. Lancia*,R,Providence 2847,4,0
+U.S. House,,Robert B. Lancia*,R,Providence 2850,13,2
+U.S. House,,Robert B. Lancia*,R,Providence 2853,9,1
+U.S. House,,Robert B. Lancia*,R,Providence 2854,16,2
+U.S. House,,Robert B. Lancia*,R,Providence 2859,1,0
+U.S. House,,Robert B. Lancia*,R,Providence 2863,15,1
+U.S. House,,Robert B. Lancia*,R,Providence 2864,2,0
+U.S. House,,Robert B. Lancia*,R,Providence 2867,1,0
+U.S. House,,Robert B. Lancia*,R,Providence 2868,1,0
+U.S. House,,Robert B. Lancia*,R,Providence 2869,3,0
+U.S. House,,Robert B. Lancia*,R,Providence 2871,6,0
+U.S. House,,Robert B. Lancia*,R,Providence 2875,17,2
+U.S. House,,Robert B. Lancia*,R,Providence 2877,2,1
+U.S. House,,Robert B. Lancia*,R,Providence Limited 2,0,0
+U.S. House,,Robert B. Lancia*,R,Richmond 2902,126,9
+U.S. House,,Robert B. Lancia*,R,Richmond Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Scituate 3001,56,9
+U.S. House,,Robert B. Lancia*,R,Scituate 3002,65,8
+U.S. House,,Robert B. Lancia*,R,Scituate 3003,54,6
+U.S. House,,Robert B. Lancia*,R,Scituate Limited,0,0
+U.S. House,,Robert B. Lancia*,R,South Kingstown 3201,10,3
+U.S. House,,Robert B. Lancia*,R,South Kingstown 3202,54,17
+U.S. House,,Robert B. Lancia*,R,South Kingstown 3204,36,5
+U.S. House,,Robert B. Lancia*,R,South Kingstown 3207,98,27
+U.S. House,,Robert B. Lancia*,R,South Kingstown 3209,17,5
+U.S. House,,Robert B. Lancia*,R,South Kingstown 3210,27,2
+U.S. House,,Robert B. Lancia*,R,South Kingstown Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Warwick 3501,42,3
+U.S. House,,Robert B. Lancia*,R,Warwick 3502,36,8
+U.S. House,,Robert B. Lancia*,R,Warwick 3503,14,1
+U.S. House,,Robert B. Lancia*,R,Warwick 3504,27,3
+U.S. House,,Robert B. Lancia*,R,Warwick 3505,9,2
+U.S. House,,Robert B. Lancia*,R,Warwick 3506,15,2
+U.S. House,,Robert B. Lancia*,R,Warwick 3507,11,2
+U.S. House,,Robert B. Lancia*,R,Warwick 3508,33,6
+U.S. House,,Robert B. Lancia*,R,Warwick 3509,8,3
+U.S. House,,Robert B. Lancia*,R,Warwick 3510,30,4
+U.S. House,,Robert B. Lancia*,R,Warwick 3511,36,11
+U.S. House,,Robert B. Lancia*,R,Warwick 3512,23,2
+U.S. House,,Robert B. Lancia*,R,Warwick 3513,36,15
+U.S. House,,Robert B. Lancia*,R,Warwick 3514,42,8
+U.S. House,,Robert B. Lancia*,R,Warwick 3515,48,6
+U.S. House,,Robert B. Lancia*,R,Warwick 3516,10,1
+U.S. House,,Robert B. Lancia*,R,Warwick 3517,13,1
+U.S. House,,Robert B. Lancia*,R,Warwick 3518,42,6
+U.S. House,,Robert B. Lancia*,R,Warwick 3519,66,9
+U.S. House,,Robert B. Lancia*,R,Warwick 3520,20,0
+U.S. House,,Robert B. Lancia*,R,Warwick 3521,25,2
+U.S. House,,Robert B. Lancia*,R,Warwick 3522,24,1
+U.S. House,,Robert B. Lancia*,R,Warwick 3523,32,6
+U.S. House,,Robert B. Lancia*,R,Warwick 3524,23,5
+U.S. House,,Robert B. Lancia*,R,Warwick 3525,27,1
+U.S. House,,Robert B. Lancia*,R,Warwick 3526,18,3
+U.S. House,,Robert B. Lancia*,R,Warwick 3527,19,2
+U.S. House,,Robert B. Lancia*,R,Warwick 3528,15,0
+U.S. House,,Robert B. Lancia*,R,Warwick 3529,34,10
+U.S. House,,Robert B. Lancia*,R,Warwick 3530,44,14
+U.S. House,,Robert B. Lancia*,R,Warwick 3531,58,8
+U.S. House,,Robert B. Lancia*,R,Warwick 3532,16,2
+U.S. House,,Robert B. Lancia*,R,Warwick 3533,15,6
+U.S. House,,Robert B. Lancia*,R,Warwick Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Westerly 3601,17,3
+U.S. House,,Robert B. Lancia*,R,Westerly 3602,16,5
+U.S. House,,Robert B. Lancia*,R,Westerly 3603,27,12
+U.S. House,,Robert B. Lancia*,R,Westerly 3604,28,13
+U.S. House,,Robert B. Lancia*,R,Westerly 3605,38,14
+U.S. House,,Robert B. Lancia*,R,Westerly 3606,14,3
+U.S. House,,Robert B. Lancia*,R,Westerly 3607,23,4
+U.S. House,,Robert B. Lancia*,R,Westerly Limited,0,0
+U.S. House,,Robert B. Lancia*,R,West Greenwich 3701,47,10
+U.S. House,,Robert B. Lancia*,R,West Greenwich 3702,28,6
+U.S. House,,Robert B. Lancia*,R,West Greenwich 3703,19,4
+U.S. House,,Robert B. Lancia*,R,West Greenwich 3704,29,9
+U.S. House,,Robert B. Lancia*,R,West Greenwich Limited,0,0
+U.S. House,,Robert B. Lancia*,R,West Warwick 3801,32,4
+U.S. House,,Robert B. Lancia*,R,West Warwick 3802,17,5
+U.S. House,,Robert B. Lancia*,R,West Warwick 3803,16,3
+U.S. House,,Robert B. Lancia*,R,West Warwick 3804,64,7
+U.S. House,,Robert B. Lancia*,R,West Warwick 3805,20,2
+U.S. House,,Robert B. Lancia*,R,West Warwick 3806,19,0
+U.S. House,,Robert B. Lancia*,R,West Warwick 3807,29,4
+U.S. House,,Robert B. Lancia*,R,West Warwick 3808,37,5
+U.S. House,,Robert B. Lancia*,R,West Warwick 3809,23,3
+U.S. House,,Robert B. Lancia*,R,West Warwick 3810,19,1
+U.S. House,,Robert B. Lancia*,R,West Warwick Limited,0,0
+U.S. House,,Robert B. Lancia*,R,Federal Precinct #2,8,4
+U.S. House,,Robert B. Lancia*,R,Federal Precinct #2S,1,1
+U.S. House,,Donald Frederick Robbio,R,Burrillville 0301,35,5
+U.S. House,,Donald Frederick Robbio,R,Burrillville 0303,53,9
+U.S. House,,Donald Frederick Robbio,R,Burrillville 0306,16,3
+U.S. House,,Donald Frederick Robbio,R,Burrillville Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Charlestown 0501,11,1
+U.S. House,,Donald Frederick Robbio,R,Charlestown 0502,10,0
+U.S. House,,Donald Frederick Robbio,R,Charlestown 0503,12,1
+U.S. House,,Donald Frederick Robbio,R,Charlestown 0504,10,1
+U.S. House,,Donald Frederick Robbio,R,Charlestown Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Coventry 0601,12,0
+U.S. House,,Donald Frederick Robbio,R,Coventry 0602,4,0
+U.S. House,,Donald Frederick Robbio,R,Coventry 0603,26,5
+U.S. House,,Donald Frederick Robbio,R,Coventry 0604,6,0
+U.S. House,,Donald Frederick Robbio,R,Coventry 0605,11,4
+U.S. House,,Donald Frederick Robbio,R,Coventry 0606,32,1
+U.S. House,,Donald Frederick Robbio,R,Coventry 0609,16,5
+U.S. House,,Donald Frederick Robbio,R,Coventry 0610,11,0
+U.S. House,,Donald Frederick Robbio,R,Coventry 0611,19,3
+U.S. House,,Donald Frederick Robbio,R,Coventry 0613,24,1
+U.S. House,,Donald Frederick Robbio,R,Coventry 0615,31,9
+U.S. House,,Donald Frederick Robbio,R,Coventry 0617,6,2
+U.S. House,,Donald Frederick Robbio,R,Coventry 0618,7,4
+U.S. House,,Donald Frederick Robbio,R,Coventry Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Cranston 0701,29,3
+U.S. House,,Donald Frederick Robbio,R,Cranston 0702,17,0
+U.S. House,,Donald Frederick Robbio,R,Cranston 0703,18,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0704,6,0
+U.S. House,,Donald Frederick Robbio,R,Cranston 0705,12,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0706,51,3
+U.S. House,,Donald Frederick Robbio,R,Cranston 0707,46,4
+U.S. House,,Donald Frederick Robbio,R,Cranston 0708,55,7
+U.S. House,,Donald Frederick Robbio,R,Cranston 0709,61,6
+U.S. House,,Donald Frederick Robbio,R,Cranston 0710,30,5
+U.S. House,,Donald Frederick Robbio,R,Cranston 0711,41,3
+U.S. House,,Donald Frederick Robbio,R,Cranston 0712,46,6
+U.S. House,,Donald Frederick Robbio,R,Cranston 0713,37,8
+U.S. House,,Donald Frederick Robbio,R,Cranston 0714,10,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0715,29,3
+U.S. House,,Donald Frederick Robbio,R,Cranston 0716,54,3
+U.S. House,,Donald Frederick Robbio,R,Cranston 0717,13,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0718,20,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0719,36,5
+U.S. House,,Donald Frederick Robbio,R,Cranston 0720,13,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0721,32,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0722,19,2
+U.S. House,,Donald Frederick Robbio,R,Cranston 0723,24,2
+U.S. House,,Donald Frederick Robbio,R,Cranston 0724,12,2
+U.S. House,,Donald Frederick Robbio,R,Cranston 0725,32,2
+U.S. House,,Donald Frederick Robbio,R,Cranston 0726,25,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0727,14,1
+U.S. House,,Donald Frederick Robbio,R,Cranston 0728,0,0
+U.S. House,,Donald Frederick Robbio,R,Cranston 0730,86,11
+U.S. House,,Donald Frederick Robbio,R,Cranston 0731,29,1
+U.S. House,,Donald Frederick Robbio,R,Cranston Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,East Greenwich 0901,5,1
+U.S. House,,Donald Frederick Robbio,R,East Greenwich 0903,21,9
+U.S. House,,Donald Frederick Robbio,R,East Greenwich 0905,25,4
+U.S. House,,Donald Frederick Robbio,R,East Greenwich Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Exeter 1101,7,0
+U.S. House,,Donald Frederick Robbio,R,Exeter 1103,19,4
+U.S. House,,Donald Frederick Robbio,R,Exeter Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Foster 1201,15,2
+U.S. House,,Donald Frederick Robbio,R,Foster Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Glocester 1301,33,4
+U.S. House,,Donald Frederick Robbio,R,Glocester 1303,3,0
+U.S. House,,Donald Frederick Robbio,R,Glocester 1304,11,1
+U.S. House,,Donald Frederick Robbio,R,Glocester Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Hopkinton 1401,15,1
+U.S. House,,Donald Frederick Robbio,R,Hopkinton 1402,10,1
+U.S. House,,Donald Frederick Robbio,R,Hopkinton 1403,6,0
+U.S. House,,Donald Frederick Robbio,R,Hopkinton Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Johnston 1601,10,0
+U.S. House,,Donald Frederick Robbio,R,Johnston 1603,14,1
+U.S. House,,Donald Frederick Robbio,R,Johnston 1604,15,5
+U.S. House,,Donald Frederick Robbio,R,Johnston 1605,8,1
+U.S. House,,Donald Frederick Robbio,R,Johnston 1606,1,0
+U.S. House,,Donald Frederick Robbio,R,Johnston 1607,2,0
+U.S. House,,Donald Frederick Robbio,R,Johnston 1608,12,1
+U.S. House,,Donald Frederick Robbio,R,Johnston 1609,7,1
+U.S. House,,Donald Frederick Robbio,R,Johnston 1610,22,5
+U.S. House,,Donald Frederick Robbio,R,Johnston 1611,14,2
+U.S. House,,Donald Frederick Robbio,R,Johnston 1612,11,0
+U.S. House,,Donald Frederick Robbio,R,Johnston 1613,6,1
+U.S. House,,Donald Frederick Robbio,R,Johnston Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Narragansett 2001,1,0
+U.S. House,,Donald Frederick Robbio,R,Narragansett 2002,24,8
+U.S. House,,Donald Frederick Robbio,R,Narragansett 2003,22,5
+U.S. House,,Donald Frederick Robbio,R,Narragansett 2004,32,3
+U.S. House,,Donald Frederick Robbio,R,Narragansett 2005,15,4
+U.S. House,,Donald Frederick Robbio,R,Narragansett Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,New Shoreham 2201,8,4
+U.S. House,,Donald Frederick Robbio,R,New Shoreham Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,North Kingstown 2301,6,1
+U.S. House,,Donald Frederick Robbio,R,North Kingstown 2304,59,10
+U.S. House,,Donald Frederick Robbio,R,North Kingstown 2306,6,0
+U.S. House,,Donald Frederick Robbio,R,North Kingstown 2309,61,12
+U.S. House,,Donald Frederick Robbio,R,North Kingstown Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2835,2,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2836,0,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2837,1,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2838,0,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2839,2,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2841,1,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2842,0,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2844,8,1
+U.S. House,,Donald Frederick Robbio,R,Providence 2846,6,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2847,1,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2850,9,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2853,3,1
+U.S. House,,Donald Frederick Robbio,R,Providence 2854,8,1
+U.S. House,,Donald Frederick Robbio,R,Providence 2859,0,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2863,5,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2864,0,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2867,1,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2868,2,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2869,4,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2871,1,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2875,21,0
+U.S. House,,Donald Frederick Robbio,R,Providence 2877,2,0
+U.S. House,,Donald Frederick Robbio,R,Providence Limited 2,0,0
+U.S. House,,Donald Frederick Robbio,R,Richmond 2902,23,2
+U.S. House,,Donald Frederick Robbio,R,Richmond Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Scituate 3001,26,5
+U.S. House,,Donald Frederick Robbio,R,Scituate 3002,24,4
+U.S. House,,Donald Frederick Robbio,R,Scituate 3003,16,4
+U.S. House,,Donald Frederick Robbio,R,Scituate Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,South Kingstown 3201,2,0
+U.S. House,,Donald Frederick Robbio,R,South Kingstown 3202,35,8
+U.S. House,,Donald Frederick Robbio,R,South Kingstown 3204,21,4
+U.S. House,,Donald Frederick Robbio,R,South Kingstown 3207,37,10
+U.S. House,,Donald Frederick Robbio,R,South Kingstown 3209,5,1
+U.S. House,,Donald Frederick Robbio,R,South Kingstown 3210,6,2
+U.S. House,,Donald Frederick Robbio,R,South Kingstown Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Warwick 3501,19,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3502,11,0
+U.S. House,,Donald Frederick Robbio,R,Warwick 3503,6,1
+U.S. House,,Donald Frederick Robbio,R,Warwick 3504,7,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3505,8,3
+U.S. House,,Donald Frederick Robbio,R,Warwick 3506,8,0
+U.S. House,,Donald Frederick Robbio,R,Warwick 3507,3,0
+U.S. House,,Donald Frederick Robbio,R,Warwick 3508,19,6
+U.S. House,,Donald Frederick Robbio,R,Warwick 3509,1,0
+U.S. House,,Donald Frederick Robbio,R,Warwick 3510,17,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3511,13,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3512,8,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3513,15,4
+U.S. House,,Donald Frederick Robbio,R,Warwick 3514,20,8
+U.S. House,,Donald Frederick Robbio,R,Warwick 3515,22,6
+U.S. House,,Donald Frederick Robbio,R,Warwick 3516,4,0
+U.S. House,,Donald Frederick Robbio,R,Warwick 3517,2,0
+U.S. House,,Donald Frederick Robbio,R,Warwick 3518,16,4
+U.S. House,,Donald Frederick Robbio,R,Warwick 3519,23,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3520,20,3
+U.S. House,,Donald Frederick Robbio,R,Warwick 3521,22,3
+U.S. House,,Donald Frederick Robbio,R,Warwick 3522,9,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3523,16,6
+U.S. House,,Donald Frederick Robbio,R,Warwick 3524,9,3
+U.S. House,,Donald Frederick Robbio,R,Warwick 3525,9,3
+U.S. House,,Donald Frederick Robbio,R,Warwick 3526,4,1
+U.S. House,,Donald Frederick Robbio,R,Warwick 3527,6,1
+U.S. House,,Donald Frederick Robbio,R,Warwick 3528,5,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3529,19,1
+U.S. House,,Donald Frederick Robbio,R,Warwick 3530,23,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3531,17,2
+U.S. House,,Donald Frederick Robbio,R,Warwick 3532,11,4
+U.S. House,,Donald Frederick Robbio,R,Warwick 3533,7,1
+U.S. House,,Donald Frederick Robbio,R,Warwick Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Westerly 3601,3,1
+U.S. House,,Donald Frederick Robbio,R,Westerly 3602,18,5
+U.S. House,,Donald Frederick Robbio,R,Westerly 3603,5,2
+U.S. House,,Donald Frederick Robbio,R,Westerly 3604,6,1
+U.S. House,,Donald Frederick Robbio,R,Westerly 3605,10,1
+U.S. House,,Donald Frederick Robbio,R,Westerly 3606,6,2
+U.S. House,,Donald Frederick Robbio,R,Westerly 3607,13,2
+U.S. House,,Donald Frederick Robbio,R,Westerly Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,West Greenwich 3701,10,1
+U.S. House,,Donald Frederick Robbio,R,West Greenwich 3702,7,2
+U.S. House,,Donald Frederick Robbio,R,West Greenwich 3703,2,0
+U.S. House,,Donald Frederick Robbio,R,West Greenwich 3704,10,1
+U.S. House,,Donald Frederick Robbio,R,West Greenwich Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3801,23,4
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3802,12,0
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3803,9,0
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3804,24,6
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3805,12,2
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3806,15,2
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3807,19,1
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3808,20,4
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3809,17,3
+U.S. House,,Donald Frederick Robbio,R,West Warwick 3810,16,2
+U.S. House,,Donald Frederick Robbio,R,West Warwick Limited,0,0
+U.S. House,,Donald Frederick Robbio,R,Federal Precinct #2,2,0
+U.S. House,,Donald Frederick Robbio,R,Federal Precinct #2S,0,0
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3801,54,8
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3802,29,5
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3803,22,3
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3804,80,11
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3805,28,5
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3807,44,5
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3808,55,8
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3809,36,5
+State Senate,,Jeffery L. Kozlin*,R,West Warwick 3810,36,3
+State Senate,,Gordon E. Rogers*,R,Coventry 0605,27,5
+State Senate,,Gordon E. Rogers*,R,Coventry 0606,90,6
+State Senate,,Gordon E. Rogers*,R,Coventry 0617,30,3
+State Senate,,Gordon E. Rogers*,R,Foster 1201,86,9
+State Senate,,Gordon E. Rogers*,R,Scituate 3001,73,15
+State Senate,,Gordon E. Rogers*,R,Scituate 3002,82,11
+State Senate,,Gordon E. Rogers*,R,Scituate 3003,65,9
+State Senate,,Gordon E. Rogers*,R,West Greenwich 3701,51,10
+State Senate,,Paul M. Santucci,R,Johnston 1606,10,1
+State Senate,,Jessica de la Cruz*,R,Burrillville 0301,102,17
+State Senate,,Jessica de la Cruz*,R,Burrillville 0303,138,22
+State Senate,,Jessica de la Cruz*,R,Burrillville 0306,42,6
+State Senate,,Jessica de la Cruz*,R,Glocester 1301,137,12
+State Senate,,Jessica de la Cruz*,R,Glocester 1303,15,0
+State Senate,,Jessica de la Cruz*,R,Glocester 1304,36,3
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0701,69,7
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0702,56,9
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0703,85,4
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0706,190,24
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0707,174,13
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0716,146,10
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0730,301,32
+State Senate,,"Anthony Fagundes, Sr.",R,Cranston 0731,146,12
+State Senate,,Pat V. Cortellessa*,R,Cranston 0708,172,33
+State Senate,,Pat V. Cortellessa*,R,Cranston 0709,238,31
+State Senate,,Pat V. Cortellessa*,R,Cranston 0710,110,15
+State Senate,,Pat V. Cortellessa*,R,Cranston 0711,126,15
+State Senate,,Pat V. Cortellessa*,R,Cranston 0712,183,27
+State Senate,,Pat V. Cortellessa*,R,Cranston 0713,218,27
+State Senate,,Pat V. Cortellessa*,R,Cranston 0717,45,5
+State Senate,,Pat V. Cortellessa*,R,Cranston 0718,80,8
+State Senate,,Pat V. Cortellessa*,R,Cranston 0719,136,7
+State Senate,,Pat V. Cortellessa*,R,Cranston 0720,46,9
+State Senate,,Pat V. Cortellessa*,R,Cranston 0728,0,0
+State Senate,,Pat V. Cortellessa*,R,West Warwick 3806,27,2
+State Senate,,Jean E. Trafford*,R,Warwick 3501,59,5
+State Senate,,Jean E. Trafford*,R,Warwick 3502,46,8
+State Senate,,Jean E. Trafford*,R,Warwick 3503,18,1
+State Senate,,Jean E. Trafford*,R,Warwick 3512,29,4
+State Senate,,Jean E. Trafford*,R,Warwick 3513,51,18
+State Senate,,Jean E. Trafford*,R,Warwick 3514,58,16
+State Senate,,Jean E. Trafford*,R,Warwick 3515,68,10
+State Senate,,Jean E. Trafford*,R,Warwick 3516,14,1
+State Senate,,Jean E. Trafford*,R,Warwick 3517,12,1
+State Senate,,Jean E. Trafford*,R,Warwick 3521,44,5
+State Senate,,Scott M. Zambarano*,R,Warwick 3504,31,5
+State Senate,,Scott M. Zambarano*,R,Warwick 3505,12,3
+State Senate,,Scott M. Zambarano*,R,Warwick 3508,38,12
+State Senate,,Scott M. Zambarano*,R,Warwick 3509,7,2
+State Senate,,Scott M. Zambarano*,R,Warwick 3510,39,5
+State Senate,,Scott M. Zambarano*,R,Warwick 3511,34,7
+State Senate,,Scott M. Zambarano*,R,Warwick 3528,19,2
+State Senate,,Scott M. Zambarano*,R,Warwick 3529,46,9
+State Senate,,Scott M. Zambarano*,R,Warwick 3530,55,15
+State Senate,,Scott M. Zambarano*,R,Warwick 3531,71,8
+State Senate,,Scott M. Zambarano*,R,Warwick 3532,21,3
+State Senate,,Scott M. Zambarano*,R,Warwick 3533,16,7
+State Senate,,John P. Silvaggio,R,Warwick 3504,3,0
+State Senate,,John P. Silvaggio,R,Warwick 3505,6,3
+State Senate,,John P. Silvaggio,R,Warwick 3508,14,0
+State Senate,,John P. Silvaggio,R,Warwick 3509,2,1
+State Senate,,John P. Silvaggio,R,Warwick 3510,9,1
+State Senate,,John P. Silvaggio,R,Warwick 3511,16,5
+State Senate,,John P. Silvaggio,R,Warwick 3528,2,0
+State Senate,,John P. Silvaggio,R,Warwick 3529,7,1
+State Senate,,John P. Silvaggio,R,Warwick 3530,15,1
+State Senate,,John P. Silvaggio,R,Warwick 3531,6,2
+State Senate,,John P. Silvaggio,R,Warwick 3532,7,3
+State Senate,,John P. Silvaggio,R,Warwick 3533,6,0
+State Senate,,Elaine J. Morgan*,R,Charlestown 0501,44,1
+State Senate,,Elaine J. Morgan*,R,Charlestown 0502,39,3
+State Senate,,Elaine J. Morgan*,R,Exeter 1101,38,5
+State Senate,,Elaine J. Morgan*,R,Exeter 1103,91,14
+State Senate,,Elaine J. Morgan*,R,Hopkinton 1401,74,10
+State Senate,,Elaine J. Morgan*,R,Hopkinton 1402,58,7
+State Senate,,Elaine J. Morgan*,R,Hopkinton 1403,21,1
+State Senate,,Elaine J. Morgan*,R,Richmond 2902,139,9
+State Senate,,Elaine J. Morgan*,R,West Greenwich 3703,21,4
+State Senate,,Charles P. Callanan*,R,East Greenwich 0903,81,24
+State Senate,,Charles P. Callanan*,R,East Greenwich 0905,85,18
+State Senate,,Charles P. Callanan*,R,Narragansett 2001,5,1
+State Senate,,Charles P. Callanan*,R,Narragansett 2004,96,16
+State Senate,,Charles P. Callanan*,R,Narragansett 2005,69,17
+State Senate,,Charles P. Callanan*,R,North Kingstown 2301,38,9
+State Senate,,Charles P. Callanan*,R,North Kingstown 2306,31,3
+State Senate,,Charles P. Callanan*,R,South Kingstown 3201,12,3
+State Senate,,Doreen M. Costa*,R,Narragansett 2002,69,15
+State Senate,,Doreen M. Costa*,R,Narragansett 2003,77,13
+State Senate,,Doreen M. Costa*,R,North Kingstown 2304,191,39
+State Senate,,Doreen M. Costa*,R,North Kingstown 2309,187,49
+State Senate,,David A. Tacey*,R,New Shoreham 2201,18,4
+State Senate,,David A. Tacey*,R,South Kingstown 3202,86,23
+State Senate,,David A. Tacey*,R,South Kingstown 3204,57,9
+State Senate,,David A. Tacey*,R,South Kingstown 3207,134,37
+State Senate,,David A. Tacey*,R,South Kingstown 3209,21,5
+State Senate,,Dennis L. Algiere*,R,Charlestown 0503,55,4
+State Senate,,Dennis L. Algiere*,R,Charlestown 0504,37,10
+State Senate,,Dennis L. Algiere*,R,South Kingstown 3210,30,4
+State Senate,,Dennis L. Algiere*,R,Westerly 3601,21,4
+State Senate,,Dennis L. Algiere*,R,Westerly 3602,34,9
+State Senate,,Dennis L. Algiere*,R,Westerly 3603,36,14
+State Senate,,Dennis L. Algiere*,R,Westerly 3604,35,13
+State Senate,,Dennis L. Algiere*,R,Westerly 3605,44,14
+State Senate,,Dennis L. Algiere*,R,Westerly 3606,17,3
+State Senate,,Dennis L. Algiere*,R,Westerly 3607,36,7
+State House,,Ronald F. Iacobbo*,R,Providence 2842,2,1
+State House,,Ronald F. Iacobbo*,R,Providence 2844,17,1
+State House,,Barbara Ann Fenton-Fung*,R,Cranston 0706,281,42
+State House,,Barbara Ann Fenton-Fung*,R,Cranston 0707,271,20
+State House,,Barbara Ann Fenton-Fung*,R,Cranston 0708,223,38
+State House,,Barbara Ann Fenton-Fung*,R,Cranston 0709,312,34
+State House,,Maryann Lancia*,R,Cranston 0710,123,21
+State House,,Maryann Lancia*,R,Cranston 0711,129,14
+State House,,Maryann Lancia*,R,Cranston 0712,180,26
+State House,,Maryann Lancia*,R,Cranston 0713,225,30
+State House,,Maryann Lancia*,R,Cranston 0714,23,1
+State House,,Maryann Lancia*,R,Cranston 0715,106,15
+State House,,Ronald A. Loparto,R,Warwick 3512,30,4
+State House,,Ronald A. Loparto,R,Warwick 3513,47,15
+State House,,Ronald A. Loparto,R,Warwick 3514,53,14
+State House,,Ronald A. Loparto,R,Warwick 3515,68,12
+State House,,Patricia L. Morgan*,R,Coventry 0603,71,11
+State House,,Patricia L. Morgan*,R,Warwick 3532,27,6
+State House,,Patricia L. Morgan*,R,West Warwick 3804,92,14
+State House,,Patricia L. Morgan*,R,West Warwick 3805,37,5
+State House,,Patricia L. Morgan*,R,West Warwick 3806,32,2
+State House,,George A. Nardone*,R,Coventry 0605,35,6
+State House,,George A. Nardone*,R,Coventry 0606,108,7
+State House,,George A. Nardone*,R,Coventry 0609,37,6
+State House,,George A. Nardone*,R,Coventry 0610,31,0
+State House,,George A. Nardone*,R,Coventry 0611,40,2
+State House,,Sherry Roberts*,R,Coventry 0613,59,8
+State House,,Sherry Roberts*,R,Coventry 0615,99,22
+State House,,Sherry Roberts*,R,West Greenwich 3701,57,12
+State House,,Sherry Roberts*,R,West Greenwich 3702,35,7
+State House,,Sherry Roberts*,R,West Greenwich 3703,18,4
+State House,,Antonio Giarrusso*,R,East Greenwich 0901,11,1
+State House,,Antonio Giarrusso*,R,East Greenwich 0903,90,25
+State House,,Antonio Giarrusso*,R,East Greenwich 0905,90,21
+State House,,Antonio Giarrusso*,R,West Greenwich 3704,38,9
+State House,,Blake A. Filippi*,R,Charlestown 0501,44,1
+State House,,Blake A. Filippi*,R,Charlestown 0502,44,4
+State House,,Blake A. Filippi*,R,Charlestown 0503,56,4
+State House,,Blake A. Filippi*,R,Charlestown 0504,40,10
+State House,,Blake A. Filippi*,R,New Shoreham 2201,21,5
+State House,,Blake A. Filippi*,R,South Kingstown 3209,23,7
+State House,,Blake A. Filippi*,R,South Kingstown 3210,33,4
+State House,,Blake A. Filippi*,R,Westerly 3601,23,4
+State House,,"Donald J. Kohlman, II*",R,Hopkinton 1401,69,7
+State House,,"Donald J. Kohlman, II*",R,Hopkinton 1402,55,6
+State House,,"Donald J. Kohlman, II*",R,Westerly 3606,21,5
+State House,,"Donald J. Kohlman, II*",R,Westerly 3607,34,6
+State House,,Justin K. Price*,R,Exeter 1103,92,14
+State House,,Justin K. Price*,R,Hopkinton 1403,20,1
+State House,,Justin K. Price*,R,Richmond 2902,140,8
+State House,,Michael W. Chippendale*,R,Coventry 0617,32,3
+State House,,Michael W. Chippendale*,R,Coventry 0618,26,7
+State House,,Michael W. Chippendale*,R,Foster 1201,97,10
+State House,,Michael W. Chippendale*,R,Glocester 1301,134,12
+State House,,Robert J. Quattrocchi*,R,Cranston 0730,336,39
+State House,,Robert J. Quattrocchi*,R,Scituate 3001,80,15
+State House,,Robert J. Quattrocchi*,R,Scituate 3002,83,11
+State House,,Robert J. Quattrocchi*,R,Scituate 3003,68,10
+State House,,Frank T. Ricci*,R,Cranston 0731,161,13
+State House,,Frank T. Ricci*,R,Johnston 1603,57,5
+State House,,Frank T. Ricci*,R,Johnston 1604,37,7
+State House,,Frank T. Ricci*,R,Johnston 1605,33,3
+State House,,Nicola Antonio Grasso*,R,Johnston 1606,10,1
+State House,,Nicola Antonio Grasso*,R,Johnston 1607,10,0
+State House,,Nicola Antonio Grasso*,R,Johnston 1608,48,8
+State House,,Nicola Antonio Grasso*,R,Johnston 1609,19,2
+State House,,Nicola Antonio Grasso*,R,Johnston 1610,48,5
+State House,,Nicola Antonio Grasso*,R,Johnston 1611,19,4
+State House,,Nicola Antonio Grasso*,R,Johnston 1612,28,3
+State House,,David J. Place*,R,Burrillville 0301,99,17
+State House,,David J. Place*,R,Burrillville 0303,142,21
+State House,,David J. Place*,R,Glocester 1303,14,0
+State House,,Brian C. Newberry*,R,Burrillville 0306,41,6
+State House,,Brian J. Rea*,R,Glocester 1304,34,3

--- a/2020/20200908__ri__primary__town.csv
+++ b/2020/20200908__ri__primary__town.csv
@@ -1,0 +1,1249 @@
+county,office,district,party,candidate,votes
+Bristol,Senator in Congress,,,Total,1498
+Bristol,Senator in Congress,,DEM,John F. Reed*,1498
+Bristol,Representative in Congress District 1,,,Total,1482
+Bristol,Representative in Congress District 1,,DEM,David N. Cicilline*,1482
+Bristol,Senator in General Assembly District 10,,,Total,394
+Bristol,Senator in General Assembly District 10,,DEM,"Walter S. Felag, Jr.*",394
+Bristol,Senator in General Assembly District 11,,,Total,404
+Bristol,Senator in General Assembly District 11,,DEM,James Arthur Seveney*,404
+Bristol,Senator in General Assembly District 32,,,Total,588
+Bristol,Senator in General Assembly District 32,,DEM,Cynthia Armour Coyne*,588
+Bristol,Representative in General Assembly District 68,,,Total,783
+Bristol,Representative in General Assembly District 68,,DEM,June S. Speakman*,783
+Bristol,Representative in General Assembly District 69,,,Total,629
+Bristol,Representative in General Assembly District 69,,DEM,Susan R. Donovan*,629
+Bristol,Town Council TOWN OF BRISTOL,,,Total,6571
+Bristol,Town Council TOWN OF BRISTOL,,DEM,Aaron J. Ley*,1289
+Bristol,Town Council TOWN OF BRISTOL,,DEM,Timothy Edward Sweeney*,1246
+Bristol,Town Council TOWN OF BRISTOL,,DEM,Bethany Sousa Foster*,1138
+Bristol,Town Council TOWN OF BRISTOL,,DEM,Adam M. Ramos*,1122
+Bristol,Town Council TOWN OF BRISTOL,,DEM,Nathan T. Calouro*,1074
+Bristol,Town Council TOWN OF BRISTOL,,DEM,"Joseph S. DeMelo, Jr.",702
+Burrillville,Senator in Congress,,,Total,540
+Burrillville,Senator in Congress,,DEM,John F. Reed*,540
+Burrillville,Representative in Congress District 2,,,Total,570
+Burrillville,Representative in Congress District 2,,DEM,James R. Langevin*,426
+Burrillville,Representative in Congress District 2,,DEM,Dylan Conley,144
+Burrillville,Senator in General Assembly District 23,,,Total,517
+Burrillville,Senator in General Assembly District 23,,DEM,Paul A. Roselli*,517
+Burrillville,Senator in Congress,,,Total,262
+Burrillville,Senator in Congress,,REP,Allen R. Waters,262
+Burrillville,Representative in Congress District 2,,,Total,279
+Burrillville,Representative in Congress District 2,,REP,Robert B. Lancia*,175
+Burrillville,Representative in Congress District 2,,REP,Donald Frederick Robbio,104
+Burrillville,Senator in General Assembly District 23,,,Total,282
+Burrillville,Senator in General Assembly District 23,,REP,Jessica de la Cruz*,282
+Burrillville,Representative in General Assembly District 47,,,Total,241
+Burrillville,Representative in General Assembly District 47,,REP,David J. Place*,241
+Burrillville,Representative in General Assembly District 48,,,Total,41
+Burrillville,Representative in General Assembly District 48,,REP,Brian C. Newberry*,41
+Central Falls,Senator in Congress,,,Total,1167
+Central Falls,Senator in Congress,,DEM,John F. Reed*,1167
+Central Falls,Representative in Congress District 1,,,Total,1292
+Central Falls,Representative in Congress District 1,,DEM,David N. Cicilline*,1292
+Central Falls,Senator in General Assembly District 16,,,Total,1536
+Central Falls,Senator in General Assembly District 16,,DEM,Jonathon Acosta,834
+Central Falls,Senator in General Assembly District 16,,DEM,Elizabeth A. Crowley*,553
+Central Falls,Senator in General Assembly District 16,,DEM,Leslie Estrada,149
+Central Falls,Representative in General Assembly District 56,,,Total,780
+Central Falls,Representative in General Assembly District 56,,DEM,Joshua J. Giraldo*,780
+Central Falls,Representative in General Assembly District 57,,,Total,320
+Central Falls,Representative in General Assembly District 57,,DEM,James N. McLaughlin*,320
+Central Falls,Non-Partisan Mayor CITY OF CENTRAL FALLS,,,Total,1874
+Central Falls,Non-Partisan Mayor CITY OF CENTRAL FALLS,,,L. Maria Rivera,1396
+Central Falls,Non-Partisan Mayor CITY OF CENTRAL FALLS,,,"Joseph P. Moran, III",314
+Central Falls,Non-Partisan Mayor CITY OF CENTRAL FALLS,,,Tia Ristaino-Siegel,164
+Charlestown,Senator in Congress,,,Total,560
+Charlestown,Senator in Congress,,DEM,John F. Reed*,560
+Charlestown,Representative in Congress District 2,,,Total,593
+Charlestown,Representative in Congress District 2,,DEM,James R. Langevin*,455
+Charlestown,Representative in Congress District 2,,DEM,Dylan Conley,138
+Charlestown,Senator in General Assembly District 34,,,Total,285
+Charlestown,Senator in General Assembly District 34,,DEM,Jennifer C. Douglas,285
+Charlestown,Senator in Congress,,,Total,164
+Charlestown,Senator in Congress,,REP,Allen R. Waters,164
+Charlestown,Representative in Congress District 2,,,Total,177
+Charlestown,Representative in Congress District 2,,REP,Robert B. Lancia*,134
+Charlestown,Representative in Congress District 2,,REP,Donald Frederick Robbio,43
+Charlestown,Senator in General Assembly District 34,,,Total,83
+Charlestown,Senator in General Assembly District 34,,REP,Elaine J. Morgan*,83
+Charlestown,Senator in General Assembly District 38,,,Total,92
+Charlestown,Senator in General Assembly District 38,,REP,Dennis L. Algiere*,92
+Charlestown,Representative in General Assembly District 36,,,Total,184
+Charlestown,Representative in General Assembly District 36,,REP,Blake A. Filippi*,184
+Coventry,Senator in Congress,,,Total,1508
+Coventry,Senator in Congress,,DEM,John F. Reed*,1508
+Coventry,Representative in Congress District 2,,,Total,1625
+Coventry,Representative in Congress District 2,,DEM,James R. Langevin*,1170
+Coventry,Representative in Congress District 2,,DEM,Dylan Conley,455
+Coventry,Senator in General Assembly District 33,,,Total,990
+Coventry,Senator in General Assembly District 33,,DEM,Leonidas P. Raptakis*,990
+Coventry,Representative in General Assembly District 25,,,Total,93
+Coventry,Representative in General Assembly District 25,,DEM,Thomas E. Noret*,93
+Coventry,Representative in General Assembly District 26,,,Total,117
+Coventry,Representative in General Assembly District 26,,DEM,James B. Jackson*,117
+Coventry,Representative in General Assembly District 27,,,Total,155
+Coventry,Representative in General Assembly District 27,,DEM,Patricia A. Serpa*,109
+Coventry,Representative in General Assembly District 27,,DEM,Nicholas E. Delmenico,46
+Coventry,Representative in General Assembly District 28,,,Total,564
+Coventry,Representative in General Assembly District 28,,DEM,Scott J. Guthrie*,564
+Coventry,Representative in General Assembly District 40,,,Total,93
+Coventry,Representative in General Assembly District 40,,DEM,Linda A. Nichols,93
+Coventry,Senator in Congress,,,Total,557
+Coventry,Senator in Congress,,REP,Allen R. Waters,557
+Coventry,Representative in Congress District 2,,,Total,634
+Coventry,Representative in Congress District 2,,REP,Robert B. Lancia*,429
+Coventry,Representative in Congress District 2,,REP,Donald Frederick Robbio,205
+Coventry,Senator in General Assembly District 21,,,Total,147
+Coventry,Senator in General Assembly District 21,,REP,Gordon E. Rogers*,147
+Coventry,Representative in General Assembly District 26,,,Total,71
+Coventry,Representative in General Assembly District 26,,REP,Patricia L. Morgan*,71
+Coventry,Representative in General Assembly District 28,,,Total,251
+Coventry,Representative in General Assembly District 28,,REP,George A. Nardone*,251
+Coventry,Representative in General Assembly District 29,,,Total,158
+Coventry,Representative in General Assembly District 29,,REP,Sherry Roberts*,158
+Coventry,Representative in General Assembly District 40,,,Total,58
+Coventry,Representative in General Assembly District 40,,REP,Michael W. Chippendale*,58
+Coventry,Non-Partisan Town Council District 5 Coventry,,,Total,641
+Coventry,Non-Partisan Town Council District 5 Coventry,,,Kimberly A. Shockley,328
+Coventry,Non-Partisan Town Council District 5 Coventry,,,Debra L. Bacon,231
+Coventry,Non-Partisan Town Council District 5 Coventry,,,Seth A. Kerstetter,82
+Cranston,Senator in Congress,,,Total,7120
+Cranston,Senator in Congress,,DEM,John F. Reed*,7120
+Cranston,Representative in Congress District 2,,,Total,7595
+Cranston,Representative in Congress District 2,,DEM,James R. Langevin*,5510
+Cranston,Representative in Congress District 2,,DEM,Dylan Conley,2085
+Cranston,Senator in General Assembly District 26,,,Total,1603
+Cranston,Senator in General Assembly District 26,,DEM,Frank S. Lombardi*,1603
+Cranston,Senator in General Assembly District 27,,,Total,2194
+Cranston,Senator in General Assembly District 27,,DEM,Hanna M. Gallo*,2194
+Cranston,Senator in General Assembly District 28,,,Total,2936
+Cranston,Senator in General Assembly District 28,,DEM,Joshua Miller*,2936
+Cranston,Representative in General Assembly District 14,,,Total,624
+Cranston,Representative in General Assembly District 14,,DEM,Charlene Lima*,624
+Cranston,Representative in General Assembly District 15,,,Total,819
+Cranston,Representative in General Assembly District 15,,DEM,Nicholas A. Mattiello*,819
+Cranston,Representative in General Assembly District 16,,,Total,1679
+Cranston,Representative in General Assembly District 16,,DEM,Brandon C. Potter,1004
+Cranston,Representative in General Assembly District 16,,DEM,Christopher T. Millea*,675
+Cranston,Representative in General Assembly District 17,,,Total,1057
+Cranston,Representative in General Assembly District 17,,DEM,Jacquelyn M. Baginski,1057
+Cranston,Representative in General Assembly District 18,,,Total,1780
+Cranston,Representative in General Assembly District 18,,DEM,Arthur Handy*,1780
+Cranston,Representative in General Assembly District 19,,,Total,323
+Cranston,Representative in General Assembly District 19,,DEM,Joseph McNamara*,191
+Cranston,Representative in General Assembly District 19,,DEM,Stuart A. Wilson,132
+Cranston,Representative in General Assembly District 20,,,Total,4
+Cranston,Representative in General Assembly District 20,,DEM,David A. Bennett*,4
+Cranston,Representative in General Assembly District 41,,,Total,268
+Cranston,Representative in General Assembly District 41,,DEM,Pamela Carosi*,191
+Cranston,Representative in General Assembly District 41,,DEM,Giuseppe Mattiello,77
+Cranston,Representative in General Assembly District 42,,,Total,231
+Cranston,Representative in General Assembly District 42,,DEM,"Edward T. Cardillo, Jr.*",231
+Cranston,Mayor CITY OF CRANSTON,,,Total,7730
+Cranston,Mayor CITY OF CRANSTON,,DEM,Maria A. Bucci,3823
+Cranston,Mayor CITY OF CRANSTON,,DEM,Steven A. Stycos,3653
+Cranston,Mayor CITY OF CRANSTON,,DEM,Adam S. Carbone,254
+Cranston,Council - City Wide CITY OF CRANSTON,,,Total,16802
+Cranston,Council - City Wide CITY OF CRANSTON,,DEM,Jessica M. Marino,5143
+Cranston,Council - City Wide CITY OF CRANSTON,,DEM,Larry Orlando Warner*,3974
+Cranston,Council - City Wide CITY OF CRANSTON,,DEM,Dylan M. Zelazo*,3946
+Cranston,Council - City Wide CITY OF CRANSTON,,DEM,Paul H. Archetto*,3739
+Cranston,Senator in Congress,,,Total,3173
+Cranston,Senator in Congress,,REP,Allen R. Waters,3173
+Cranston,Representative in Congress District 2,,,Total,4090
+Cranston,Representative in Congress District 2,,REP,Robert B. Lancia*,3193
+Cranston,Representative in Congress District 2,,REP,Donald Frederick Robbio,897
+Cranston,Senator in General Assembly District 26,,,Total,1167
+Cranston,Senator in General Assembly District 26,,REP,"Anthony Fagundes, Sr.",1167
+Cranston,Senator in General Assembly District 27,,,Total,1354
+Cranston,Senator in General Assembly District 27,,REP,Pat V. Cortellessa*,1354
+Cranston,Representative in General Assembly District 15,,,Total,1087
+Cranston,Representative in General Assembly District 15,,REP,Barbara Ann Fenton-Fung*,1087
+Cranston,Representative in General Assembly District 16,,,Total,786
+Cranston,Representative in General Assembly District 16,,REP,Maryann Lancia*,786
+Cranston,Representative in General Assembly District 41,,,Total,336
+Cranston,Representative in General Assembly District 41,,REP,Robert J. Quattrocchi*,336
+Cranston,Representative in General Assembly District 42,,,Total,161
+Cranston,Representative in General Assembly District 42,,REP,Frank T. Ricci*,161
+Cranston,Mayor CITY OF CRANSTON,,,Total,4610
+Cranston,Mayor CITY OF CRANSTON,,REP,Kenneth J. Hopkins,3525
+Cranston,Mayor CITY OF CRANSTON,,REP,Michael J. Farina*,1085
+Cumberland,Senator in Congress,,,Total,876
+Cumberland,Senator in Congress,,DEM,John F. Reed*,876
+Cumberland,Representative in Congress District 1,,,Total,845
+Cumberland,Representative in Congress District 1,,DEM,David N. Cicilline*,845
+Cumberland,Senator in General Assembly District 19,,,Total,298
+Cumberland,Senator in General Assembly District 19,,DEM,Ryan W. Pearson*,298
+Cumberland,Senator in General Assembly District 20,,,Total,529
+Cumberland,Senator in General Assembly District 20,,DEM,Roger A. Picard*,529
+Cumberland,Representative in General Assembly District 45,,,Total,546
+Cumberland,Representative in General Assembly District 45,,DEM,Mia A. Ackerman*,546
+Cumberland,Representative in General Assembly District 51,,,Total,29
+Cumberland,Representative in General Assembly District 51,,DEM,Robert D. Phillips,29
+Cumberland,Representative in General Assembly District 52,,,Total,68
+Cumberland,Representative in General Assembly District 52,,DEM,Alex D. Marszalkowski*,68
+Cumberland,Representative in General Assembly District 57,,,Total,193
+Cumberland,Representative in General Assembly District 57,,DEM,James N. McLaughlin*,193
+Cumberland,Town Council District 2 Cumberland,,,Total,721
+Cumberland,Town Council District 2 Cumberland,,DEM,"Timothy C. Magill, Jr.",450
+Cumberland,Town Council District 2 Cumberland,,DEM,Thomas W. Kane*,271
+Cumberland,Senatorial District Committee District 20,,,Total,3042
+Cumberland,Senatorial District Committee District 20,,DEM,Caitlyn L. Picard*,435
+Cumberland,Senatorial District Committee District 20,,DEM,Debra A. LeClerc*,410
+Cumberland,Senatorial District Committee District 20,,DEM,Jeanne C. DeBroisse*,386
+Cumberland,Senatorial District Committee District 20,,DEM,Lisa M. Mencucci*,366
+Cumberland,Senatorial District Committee District 20,,DEM,Leslie A. Page,336
+Cumberland,Senatorial District Committee District 20,,DEM,Douglas E. Connell*,298
+Cumberland,Senatorial District Committee District 20,,DEM,Nathan R. Carpenter,280
+Cumberland,Senatorial District Committee District 20,,DEM,"Angelo A. Mencucci, Jr.*",271
+Cumberland,Senatorial District Committee District 20,,DEM,Johnathan D. Berard,260
+East Greenwich,Senator in Congress,,,Total,859
+East Greenwich,Senator in Congress,,DEM,John F. Reed*,859
+East Greenwich,Representative in Congress District 2,,,Total,895
+East Greenwich,Representative in Congress District 2,,DEM,James R. Langevin*,624
+East Greenwich,Representative in Congress District 2,,DEM,Dylan Conley,271
+East Greenwich,Senator in General Assembly District 33,,,Total,48
+East Greenwich,Senator in General Assembly District 33,,DEM,Leonidas P. Raptakis*,48
+East Greenwich,Senator in General Assembly District 35,,,Total,768
+East Greenwich,Senator in General Assembly District 35,,DEM,Bridget G. Valverde*,768
+East Greenwich,Representative in General Assembly District 30,,,Total,827
+East Greenwich,Representative in General Assembly District 30,,DEM,Justine A. Caldwell*,827
+East Greenwich,Senator in Congress,,,Total,175
+East Greenwich,Senator in Congress,,REP,Allen R. Waters,175
+East Greenwich,Representative in Congress District 2,,,Total,188
+East Greenwich,Representative in Congress District 2,,REP,Robert B. Lancia*,137
+East Greenwich,Representative in Congress District 2,,REP,Donald Frederick Robbio,51
+East Greenwich,Senator in General Assembly District 35,,,Total,166
+East Greenwich,Senator in General Assembly District 35,,REP,Charles P. Callanan*,166
+East Greenwich,Representative in General Assembly District 30,,,Total,191
+East Greenwich,Representative in General Assembly District 30,,REP,Antonio Giarrusso*,191
+East Providence,Senator in Congress,,,Total,2569
+East Providence,Senator in Congress,,DEM,John F. Reed*,2569
+East Providence,Representative in Congress District 1,,,Total,2695
+East Providence,Representative in Congress District 1,,DEM,David N. Cicilline*,2695
+East Providence,Senator in General Assembly District 14,,,Total,1011
+East Providence,Senator in General Assembly District 14,,DEM,Valarie J. Lawson*,1011
+East Providence,Senator in General Assembly District 18,,,Total,1733
+East Providence,Senator in General Assembly District 18,,DEM,Cynthia M. Mendes,1125
+East Providence,Senator in General Assembly District 18,,DEM,"William J. Conley, Jr.*",608
+East Providence,Representative in General Assembly District 63,,,Total,751
+East Providence,Representative in General Assembly District 63,,DEM,Katherine S. Kazarian*,751
+East Providence,Representative in General Assembly District 64,,,Total,1180
+East Providence,Representative in General Assembly District 64,,DEM,Brianna E. Henries,727
+East Providence,Representative in General Assembly District 64,,DEM,Jose R. Serodio*,453
+East Providence,Representative in General Assembly District 65,,,Total,625
+East Providence,Representative in General Assembly District 65,,DEM,Gregg Amore*,625
+East Providence,Representative in General Assembly District 66,,,Total,146
+East Providence,Representative in General Assembly District 66,,DEM,Liana M. Cassar*,146
+East Providence,Senatorial District Committee District 18,,,Total,8091
+East Providence,Senatorial District Committee District 18,,DEM,Debra J. Cook*,874
+East Providence,Senatorial District Committee District 18,,DEM,Emily N. Mercer*,835
+East Providence,Senatorial District Committee District 18,,DEM,Sharlene L. Damiani*,819
+East Providence,Senatorial District Committee District 18,,DEM,Robin M. Bothelo*,817
+East Providence,Senatorial District Committee District 18,,DEM,Patricia Ann Scorpio*,771
+East Providence,Senatorial District Committee District 18,,DEM,Norma J. Conley*,728
+East Providence,Senatorial District Committee District 18,,DEM,Emily R. Walter,723
+East Providence,Senatorial District Committee District 18,,DEM,Christen D. Sherman,562
+East Providence,Senatorial District Committee District 18,,DEM,Joseph C. Knight*,547
+East Providence,Senatorial District Committee District 18,,DEM,Jarrett R. McPhee,486
+East Providence,Senatorial District Committee District 18,,DEM,Gregory R. Greco,481
+East Providence,Senatorial District Committee District 18,,DEM,Lee G. Wilder,448
+East Providence,Representative District Committee District 64,,,Total,2567
+East Providence,Representative District Committee District 64,,DEM,Helio Melo*,649
+East Providence,Representative District Committee District 64,,DEM,Mary Rose Pacheco*,647
+East Providence,Representative District Committee District 64,,DEM,Bryan P. Silva*,502
+East Providence,Representative District Committee District 64,,DEM,Caely A. Flynn,401
+East Providence,Representative District Committee District 64,,DEM,Kevin M. Silveira,368
+East Providence,School Committee Ward 2 East Providence,,,Total,882
+East Providence,School Committee Ward 2 East Providence,,,Max D. Brandle,373
+East Providence,School Committee Ward 2 East Providence,,,Anthony J. Ferreira,351
+East Providence,School Committee Ward 2 East Providence,,,Damian S. Ramos,158
+Exeter,Senator in Congress,,,Total,311
+Exeter,Senator in Congress,,DEM,John F. Reed*,311
+Exeter,Representative in Congress District 2,,,Total,325
+Exeter,Representative in Congress District 2,,DEM,James R. Langevin*,228
+Exeter,Representative in Congress District 2,,DEM,Dylan Conley,97
+Exeter,Senator in General Assembly District 34,,,Total,291
+Exeter,Senator in General Assembly District 34,,DEM,Jennifer C. Douglas,291
+Exeter,Representative in General Assembly District 31,,,Total,94
+Exeter,Representative in General Assembly District 31,,DEM,Julie A. Casimiro*,94
+Exeter,Representative in General Assembly District 39,,,Total,207
+Exeter,Representative in General Assembly District 39,,DEM,Megan L. Cotter*,207
+Exeter,Senator in Congress,,,Total,117
+Exeter,Senator in Congress,,REP,Allen R. Waters,117
+Exeter,Representative in Congress District 2,,,Total,134
+Exeter,Representative in Congress District 2,,REP,Robert B. Lancia*,108
+Exeter,Representative in Congress District 2,,REP,Donald Frederick Robbio,26
+Exeter,Senator in General Assembly District 34,,,Total,129
+Exeter,Senator in General Assembly District 34,,REP,Elaine J. Morgan*,129
+Exeter,Representative in General Assembly District 39,,,Total,92
+Exeter,Representative in General Assembly District 39,,REP,Justin K. Price*,92
+Foster,Senator in Congress,,,Total,195
+Foster,Senator in Congress,,DEM,John F. Reed*,195
+Foster,Representative in Congress District 2,,,Total,209
+Foster,Representative in Congress District 2,,DEM,James R. Langevin*,147
+Foster,Representative in Congress District 2,,DEM,Dylan Conley,62
+Foster,Representative in General Assembly District 40,,,Total,193
+Foster,Representative in General Assembly District 40,,DEM,Linda A. Nichols,193
+Foster,Senator in Congress,,,Total,88
+Foster,Senator in Congress,,REP,Allen R. Waters,88
+Foster,Representative in Congress District 2,,,Total,95
+Foster,Representative in Congress District 2,,REP,Robert B. Lancia*,80
+Foster,Representative in Congress District 2,,REP,Donald Frederick Robbio,15
+Foster,Senator in General Assembly District 21,,,Total,86
+Foster,Senator in General Assembly District 21,,REP,Gordon E. Rogers*,86
+Foster,Representative in General Assembly District 40,,,Total,97
+Foster,Representative in General Assembly District 40,,REP,Michael W. Chippendale*,97
+Glocester,Senator in Congress,,,Total,407
+Glocester,Senator in Congress,,DEM,John F. Reed*,407
+Glocester,Representative in Congress District 2,,,Total,417
+Glocester,Representative in Congress District 2,,DEM,James R. Langevin*,309
+Glocester,Representative in Congress District 2,,DEM,Dylan Conley,108
+Glocester,Senator in General Assembly District 23,,,Total,379
+Glocester,Senator in General Assembly District 23,,DEM,Paul A. Roselli*,379
+Glocester,Representative in General Assembly District 40,,,Total,255
+Glocester,Representative in General Assembly District 40,,DEM,Linda A. Nichols,255
+Glocester,Representative in General Assembly District 53,,,Total,82
+Glocester,Representative in General Assembly District 53,,DEM,Bernard A. Hawkins*,82
+Glocester,Senator in Congress,,,Total,175
+Glocester,Senator in Congress,,REP,Allen R. Waters,175
+Glocester,Representative in Congress District 2,,,Total,186
+Glocester,Representative in Congress District 2,,REP,Robert B. Lancia*,139
+Glocester,Representative in Congress District 2,,REP,Donald Frederick Robbio,47
+Glocester,Senator in General Assembly District 23,,,Total,188
+Glocester,Senator in General Assembly District 23,,REP,Jessica de la Cruz*,188
+Glocester,Representative in General Assembly District 40,,,Total,134
+Glocester,Representative in General Assembly District 40,,REP,Michael W. Chippendale*,134
+Glocester,Representative in General Assembly District 47,,,Total,14
+Glocester,Representative in General Assembly District 47,,REP,David J. Place*,14
+Glocester,Representative in General Assembly District 53,,,Total,34
+Glocester,Representative in General Assembly District 53,,REP,Brian J. Rea*,34
+Hopkinton,Senator in Congress,,,Total,486
+Hopkinton,Senator in Congress,,DEM,John F. Reed*,486
+Hopkinton,Representative in Congress District 2,,,Total,519
+Hopkinton,Representative in Congress District 2,,DEM,James R. Langevin*,382
+Hopkinton,Representative in Congress District 2,,DEM,Dylan Conley,137
+Hopkinton,Senator in General Assembly District 34,,,Total,457
+Hopkinton,Senator in General Assembly District 34,,DEM,Jennifer C. Douglas,457
+Hopkinton,Representative in General Assembly District 38,,,Total,461
+Hopkinton,Representative in General Assembly District 38,,DEM,Brian Patrick Kennedy*,295
+Hopkinton,Representative in General Assembly District 38,,DEM,Miguel J. Torres,166
+Hopkinton,Representative in General Assembly District 39,,,Total,57
+Hopkinton,Representative in General Assembly District 39,,DEM,Megan L. Cotter*,57
+Hopkinton,Senator in Congress,,,Total,144
+Hopkinton,Senator in Congress,,REP,Allen R. Waters,144
+Hopkinton,Representative in Congress District 2,,,Total,155
+Hopkinton,Representative in Congress District 2,,REP,Robert B. Lancia*,124
+Hopkinton,Representative in Congress District 2,,REP,Donald Frederick Robbio,31
+Hopkinton,Senator in General Assembly District 34,,,Total,153
+Hopkinton,Senator in General Assembly District 34,,REP,Elaine J. Morgan*,153
+Hopkinton,Representative in General Assembly District 38,,,Total,124
+Hopkinton,Representative in General Assembly District 38,,REP,"Donald J. Kohlman, II*",124
+Hopkinton,Representative in General Assembly District 39,,,Total,20
+Hopkinton,Representative in General Assembly District 39,,REP,Justin K. Price*,20
+Jamestown,Senator in Congress,,,Total,1155
+Jamestown,Senator in Congress,,DEM,John F. Reed*,1155
+Jamestown,Representative in Congress District 1,,,Total,1135
+Jamestown,Representative in Congress District 1,,DEM,David N. Cicilline*,1135
+Jamestown,Senator in General Assembly District 13,,,Total,1112
+Jamestown,Senator in General Assembly District 13,,DEM,Dawn M. Euer*,1112
+Jamestown,Representative in General Assembly District 74,,,Total,1234
+Jamestown,Representative in General Assembly District 74,,DEM,Deborah L. Ruggiero*,1136
+Jamestown,Representative in General Assembly District 74,,DEM,"Henry F. Lombardi, Jr.",98
+Johnston,Senator in Congress,,,Total,2127
+Johnston,Senator in Congress,,DEM,John F. Reed*,2127
+Johnston,Representative in Congress District 2,,,Total,2522
+Johnston,Representative in Congress District 2,,DEM,James R. Langevin*,1691
+Johnston,Representative in Congress District 2,,DEM,Dylan Conley,831
+Johnston,Senator in General Assembly District 22,,,Total,57
+Johnston,Senator in General Assembly District 22,,DEM,Stephen R. Archambault*,30
+Johnston,Senator in General Assembly District 22,,DEM,Melanie G. DuPont,27
+Johnston,Senator in General Assembly District 25,,,Total,2021
+Johnston,Senator in General Assembly District 25,,DEM,"Frank Lombardo, III*",2021
+Johnston,Representative in General Assembly District 13,,,Total,250
+Johnston,Representative in General Assembly District 13,,DEM,Ramon A. Perez,137
+Johnston,Representative in General Assembly District 13,,DEM,Mario F. Mendez*,89
+Johnston,Representative in General Assembly District 13,,DEM,Janice A. Falconer,24
+Johnston,Representative in General Assembly District 42,,,Total,477
+Johnston,Representative in General Assembly District 42,,DEM,"Edward T. Cardillo, Jr.*",477
+Johnston,Representative in General Assembly District 43,,,Total,1607
+Johnston,Representative in General Assembly District 43,,DEM,Deborah A. Fellela*,1013
+Johnston,Representative in General Assembly District 43,,DEM,Melinda Lopez,594
+Johnston,Representative in General Assembly District 44,,,Total,122
+Johnston,Representative in General Assembly District 44,,DEM,Gregory J. Costantino*,122
+Johnston,Town Council District 4 Johnston,,,Total,844
+Johnston,Town Council District 4 Johnston,,DEM,Robert V. Russo*,503
+Johnston,Town Council District 4 Johnston,,DEM,Kevin P. Millonzi,341
+Johnston,Senatorial District Committee District 22,,,Total,243
+Johnston,Senatorial District Committee District 22,,DEM,S. Jean Cerroni*,36
+Johnston,Senatorial District Committee District 22,,DEM,Pasquale A. Matteo*,34
+Johnston,Senatorial District Committee District 22,,DEM,Lawrence J. Mancini*,33
+Johnston,Senatorial District Committee District 22,,DEM,Charles T. Jackvony*,32
+Johnston,Senatorial District Committee District 22,,DEM,Peter B. Simone*,30
+Johnston,Senatorial District Committee District 22,,DEM,James K. McNelis*,27
+Johnston,Senatorial District Committee District 22,,DEM,Timothy F. Kane*,27
+Johnston,Senatorial District Committee District 22,,DEM,Mycala J. McKay,24
+Johnston,Senator in Congress,,,Total,336
+Johnston,Senator in Congress,,REP,Allen R. Waters,336
+Johnston,Representative in Congress District 2,,,Total,377
+Johnston,Representative in Congress District 2,,REP,Robert B. Lancia*,255
+Johnston,Representative in Congress District 2,,REP,Donald Frederick Robbio,122
+Johnston,Senator in General Assembly District 22,,,Total,10
+Johnston,Senator in General Assembly District 22,,REP,Paul M. Santucci,10
+Johnston,Representative in General Assembly District 42,,,Total,127
+Johnston,Representative in General Assembly District 42,,REP,Frank T. Ricci*,127
+Johnston,Representative in General Assembly District 43,,,Total,182
+Johnston,Representative in General Assembly District 43,,REP,Nicola Antonio Grasso*,182
+Little Compton,Senator in Congress,,,Total,497
+Little Compton,Senator in Congress,,DEM,John F. Reed*,497
+Little Compton,Representative in Congress District 1,,,Total,508
+Little Compton,Representative in Congress District 1,,DEM,David N. Cicilline*,508
+Little Compton,Senator in General Assembly District 12,,,Total,454
+Little Compton,Senator in General Assembly District 12,,DEM,Louis P. DiPalma*,454
+Little Compton,Representative in General Assembly District 71,,,Total,559
+Little Compton,Representative in General Assembly District 71,,DEM,Michelle E. McGaw,496
+Little Compton,Representative in General Assembly District 71,,DEM,"John G. Edwards, V*",63
+Little Compton,Representative District Committee District 71,,,Total,2271
+Little Compton,Representative District Committee District 71,,DEM,Michelle E. McGaw,490
+Little Compton,Representative District Committee District 71,,DEM,Anya R. Wallack,358
+Little Compton,Representative District Committee District 71,,DEM,Christopher E. Goulart,349
+Little Compton,Representative District Committee District 71,,DEM,Maureen Evelyn Molloy Morrow,280
+Little Compton,Representative District Committee District 71,,DEM,Glenn Diana Sherman,262
+Little Compton,Representative District Committee District 71,,DEM,Kimberley J. Waltz*,123
+Little Compton,Representative District Committee District 71,,DEM,"John G. Edwards, V*",121
+Little Compton,Representative District Committee District 71,,DEM,Amy J. Canario*,102
+Little Compton,Representative District Committee District 71,,DEM,Brittany T. Edwards*,96
+Little Compton,Representative District Committee District 71,,DEM,Dennis M. Canario*,90
+Middletown,Senator in Congress,,,Total,1006
+Middletown,Senator in Congress,,DEM,John F. Reed*,1006
+Middletown,Representative in Congress District 1,,,Total,1025
+Middletown,Representative in Congress District 1,,DEM,David N. Cicilline*,1025
+Middletown,Senator in General Assembly District 12,,,Total,983
+Middletown,Senator in General Assembly District 12,,DEM,Louis P. DiPalma*,983
+Middletown,Representative in General Assembly District 72,,,Total,537
+Middletown,Representative in General Assembly District 72,,DEM,Terri-Denise Cortvriend*,377
+Middletown,Representative in General Assembly District 72,,DEM,Christopher T. Semonelli,160
+Middletown,Representative in General Assembly District 74,,,Total,584
+Middletown,Representative in General Assembly District 74,,DEM,Deborah L. Ruggiero*,436
+Middletown,Representative in General Assembly District 74,,DEM,"Henry F. Lombardi, Jr.",148
+Narragansett,Senator in Congress,,,Total,1902
+Narragansett,Senator in Congress,,DEM,John F. Reed*,1902
+Narragansett,Representative in Congress District 2,,,Total,2101
+Narragansett,Representative in Congress District 2,,DEM,James R. Langevin*,1514
+Narragansett,Representative in Congress District 2,,DEM,Dylan Conley,587
+Narragansett,Senator in General Assembly District 35,,,Total,883
+Narragansett,Senator in General Assembly District 35,,DEM,Bridget G. Valverde*,883
+Narragansett,Senator in General Assembly District 36,,,Total,957
+Narragansett,Senator in General Assembly District 36,,DEM,Alana DiMario*,808
+Narragansett,Senator in General Assembly District 36,,DEM,Ellen S. Waxman,149
+Narragansett,Representative in General Assembly District 33,,,Total,910
+Narragansett,Representative in General Assembly District 33,,DEM,Carol Hagan McEntee*,910
+Narragansett,Representative in General Assembly District 34,,,Total,1044
+Narragansett,Representative in General Assembly District 34,,DEM,Teresa A. Tanzi*,713
+Narragansett,Representative in General Assembly District 34,,DEM,Gina M. Giramma,331
+Narragansett,Senator in Congress,,,Total,291
+Narragansett,Senator in Congress,,REP,Allen R. Waters,291
+Narragansett,Representative in Congress District 2,,,Total,317
+Narragansett,Representative in Congress District 2,,REP,Robert B. Lancia*,223
+Narragansett,Representative in Congress District 2,,REP,Donald Frederick Robbio,94
+Narragansett,Senator in General Assembly District 35,,,Total,170
+Narragansett,Senator in General Assembly District 35,,REP,Charles P. Callanan*,170
+Narragansett,Senator in General Assembly District 36,,,Total,146
+Narragansett,Senator in General Assembly District 36,,REP,Doreen M. Costa*,146
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Total,13392
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Jesse Pugh,1849
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Susan P. Cicilline Buonanno,1701
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Patrick W. Murray,1203
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Ewa M. Dzwierzynski,1042
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Deborah A. Kopech,852
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Laurie A. Kelly,805
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Jill A. Lawler,726
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Richard M. Lema,689
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,"Winters B. Hames, III",686
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Steven B. Belaus,679
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,"Michael J. Millen, Jr.",668
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,David K. Avedisian,656
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Joseph Robenhymer,648
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Steven J. Ferrandi,561
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Meghan E. Murray,341
+Narragansett,Non-Partisan Town Council TOWN OF NARRAGANSETT,,,Sara L. Benn,286
+New Shoreham,Senator in Congress,,,Total,199
+New Shoreham,Senator in Congress,,DEM,John F. Reed*,199
+New Shoreham,Representative in Congress District 2,,,Total,218
+New Shoreham,Representative in Congress District 2,,DEM,James R. Langevin*,190
+New Shoreham,Representative in Congress District 2,,DEM,Dylan Conley,28
+New Shoreham,Senator in General Assembly District 37,,,Total,218
+New Shoreham,Senator in General Assembly District 37,,DEM,Virginia S. Sosnowski*,138
+New Shoreham,Senator in General Assembly District 37,,DEM,Maggie A. Kain,80
+New Shoreham,Senatorial District Committee District 37,,,Total,949
+New Shoreham,Senatorial District Committee District 37,,DEM,Kimberley H. Gaffett*,188
+New Shoreham,Senatorial District Committee District 37,,DEM,Virginia S. Sosnowski*,144
+New Shoreham,Senatorial District Committee District 37,,DEM,Maggie A. Kain,101
+New Shoreham,Senatorial District Committee District 37,,DEM,Joshua T. Maldonado,80
+New Shoreham,Senatorial District Committee District 37,,DEM,Leanne M. Peckham*,70
+New Shoreham,Senatorial District Committee District 37,,DEM,John M. Rose*,63
+New Shoreham,Senatorial District Committee District 37,,DEM,Deborah J. Kelso*,59
+New Shoreham,Senatorial District Committee District 37,,DEM,Patricia Breslin Filippo*,53
+New Shoreham,Senatorial District Committee District 37,,DEM,Terrence G. Simpson*,45
+New Shoreham,Senatorial District Committee District 37,,DEM,Emily R. Cotter,37
+New Shoreham,Senatorial District Committee District 37,,DEM,Sarah E. Markey,36
+New Shoreham,Senatorial District Committee District 37,,DEM,Judith A. Kain,28
+New Shoreham,Senatorial District Committee District 37,,DEM,Tara M. Apperson,19
+New Shoreham,Senatorial District Committee District 37,,DEM,"Robert W. Widell, Jr.",14
+New Shoreham,Senatorial District Committee District 37,,DEM,Torrey R. Martin,12
+New Shoreham,Senator in Congress,,,Total,19
+New Shoreham,Senator in Congress,,REP,Allen R. Waters,19
+New Shoreham,Representative in Congress District 2,,,Total,20
+New Shoreham,Representative in Congress District 2,,REP,Robert B. Lancia*,12
+New Shoreham,Representative in Congress District 2,,REP,Donald Frederick Robbio,8
+New Shoreham,Senator in General Assembly District 37,,,Total,18
+New Shoreham,Senator in General Assembly District 37,,REP,David A. Tacey*,18
+New Shoreham,Representative in General Assembly District 36,,,Total,21
+New Shoreham,Representative in General Assembly District 36,,REP,Blake A. Filippi*,21
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Total,10425
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Jamie P. Bova,1511
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Jeanne-Marie Napolitano,1218
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Susan D. Taylor,1178
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Lynn Underwood Ceglie,1111
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Justin S. McLaughlin,934
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Kevin Michaud,919
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Elizabeth Fuerte,822
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Elizabeth Evans Cullen,707
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,William E. Kimes,642
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Meagan E. Landry,627
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Olga H. Enger,465
+Newport,Non-Partisan Council-At-Large CITY OF NEWPORT,,,Derek W. Grinkin,291
+Newport,Non-Partisan Council Ward 3 Newport,,,Total,1144
+Newport,Non-Partisan Council Ward 3 Newport,,,Paul E. Marshall,640
+Newport,Non-Partisan Council Ward 3 Newport,,,Kathryn E. Leonard,445
+Newport,Non-Partisan Council Ward 3 Newport,,,Rachel S. Hussey,59
+North Kingstown,Senator in Congress,,,Total,2750
+North Kingstown,Senator in Congress,,DEM,John F. Reed*,2750
+North Kingstown,Representative in Congress District 2,,,Total,2912
+North Kingstown,Representative in Congress District 2,,DEM,James R. Langevin*,2127
+North Kingstown,Representative in Congress District 2,,DEM,Dylan Conley,785
+North Kingstown,Senator in General Assembly District 35,,,Total,452
+North Kingstown,Senator in General Assembly District 35,,DEM,Bridget G. Valverde*,452
+North Kingstown,Senator in General Assembly District 36,,,Total,2366
+North Kingstown,Senator in General Assembly District 36,,DEM,Alana DiMario*,1691
+North Kingstown,Senator in General Assembly District 36,,DEM,Ellen S. Waxman,675
+North Kingstown,Representative in General Assembly District 31,,,Total,1031
+North Kingstown,Representative in General Assembly District 31,,DEM,Julie A. Casimiro*,1031
+North Kingstown,Representative in General Assembly District 32,,,Total,1526
+North Kingstown,Representative in General Assembly District 32,,DEM,Robert E. Craven*,1526
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,,Total,12586
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,DEM,Kimberly Ann Page*,2371
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,DEM,Gregory A. Mancini,2192
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,DEM,Katherine K. Anderson,2122
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,DEM,Brad L. Artery*,1822
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,DEM,John D. Kliever,1812
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,DEM,Richard A. Welch*,1140
+North Kingstown,Town Council TOWN OF NORTH KINGSTOWN,,DEM,Rickey L. Thompson*,1127
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,,Total,61394
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Gregory A. Mancini*,1756
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,John D. Kliever*,1506
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Kimberly Ann Page,1435
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Julia F. Kliever*,1332
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Katherine K. Anderson,1273
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Julie A. Casimiro*,1220
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Lisa A. Hildebrand*,1181
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Bridget G. Valverde*,1176
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Melissa K. Devine*,1156
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,James C. Sheehan*,1141
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Suzanne S. Mancini,1137
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Gregory B. Blasbalg*,1120
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Mary N. Thomson*,985
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Meredith L. Sheehan*,969
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Carrie M. Kolb*,966
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Theresa M. Mrozak*,943
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Nancy W. Sherman,924
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Jennifer S. Lima,917
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,"Thomas A. Sgouros, Jr.*",884
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,"John Pyne, Jr.*",875
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Lisa G. Andrews,866
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Elizabeth C. Dwyer,856
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Rickey L. Thompson*,850
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,"Edward J. Cooney, Jr.*",849
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,William A. Valverde*,847
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Meggen R. Chabot,846
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Susan M. Eriksen,804
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Kayla M. Robinson,795
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Pamela B. Ong,786
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Margaret Kerr,778
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Richard A. Welch*,777
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Jennifer Louise Wheeler,771
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Anne K. Geertman,765
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Claire S. Duva*,762
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Jennifer P. Hoskins,757
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Mary N. Worobec,757
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Nicole M. Grace,743
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Alice A. Rose,739
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Meredith N. Whittaker*,735
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Susan D. Coletta*,727
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Tracey A. McCue*,715
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Lisa G. Faulise,698
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Janet Boyle Welch*,684
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Kahlia Shmerer,673
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Dolores J. Burke*,669
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Michael R. Anderson,652
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Chloe R. Eminger,646
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Sharon F. Williams*,633
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Robert R. Vanderslice,627
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,John Machata,622
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Georgine M. Edwards,617
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,"John V. Gibbons, Jr.*",610
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Jacob W. Mather,574
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Dylan J. Kennedy,565
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,David H. Oppenheimer,563
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Edwin F. Andrews,551
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,James Robert Grundy*,544
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Richard J. Beneduce*,535
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Thomas C. Ardito,525
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Emilio Coletta*,515
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Daniel J. Burke*,512
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Glenn W. Stinson,512
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Peter Charles Cornillon,484
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Paul A. Geertman,482
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Jonathan K. Gale,479
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Michael J. Burke*,474
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Julie A. Grundy,471
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,"Mark G. Walsh, Jr.*",468
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Peter Haines Doering,463
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Colleen E. Emerson,460
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,David F. McCue*,453
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Richard H. Sellers,453
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Jacob D. Clemen,452
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Donna L. Beneduce,433
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Alan B. Hurd*,430
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Arthur L. Simonini*,414
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Ronald R. Harrison*,407
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Diana B. Christie,404
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Michael A. Mollis,322
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Patrick S. O&#39;Rourke,264
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Matthew D. Wild,238
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Christopher E. Emerson,231
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Gabriel K. Cote,227
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Keith A. Sullivan,226
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Patrick F. Dyer,222
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,William J. Barrett,190
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,David J. Davy,154
+North Kingstown,Town Committee TOWN OF NORTH KINGSTOWN,,DEM,Bryan L. Bonneau,145
+North Kingstown,Senator in Congress,,,Total,427
+North Kingstown,Senator in Congress,,REP,Allen R. Waters,427
+North Kingstown,Representative in Congress District 2,,,Total,444
+North Kingstown,Representative in Congress District 2,,REP,Robert B. Lancia*,312
+North Kingstown,Representative in Congress District 2,,REP,Donald Frederick Robbio,132
+North Kingstown,Senator in General Assembly District 35,,,Total,69
+North Kingstown,Senator in General Assembly District 35,,REP,Charles P. Callanan*,69
+North Kingstown,Senator in General Assembly District 36,,,Total,378
+North Kingstown,Senator in General Assembly District 36,,REP,Doreen M. Costa*,378
+North Providence,Senator in Congress,,,Total,2929
+North Providence,Senator in Congress,,DEM,John F. Reed*,2929
+North Providence,Representative in Congress District 1,,,Total,2818
+North Providence,Representative in Congress District 1,,DEM,David N. Cicilline*,2818
+North Providence,Senator in General Assembly District 4,,,Total,2516
+North Providence,Senator in General Assembly District 4,,DEM,Dominick J. Ruggerio*,1550
+North Providence,Senator in General Assembly District 4,,DEM,"Leonardo A. Cioe, Jr.",966
+North Providence,Senator in General Assembly District 15,,,Total,196
+North Providence,Senator in General Assembly District 15,,DEM,"Robert H. Morris, Jr.",111
+North Providence,Senator in General Assembly District 15,,DEM,Meghan E. Kallman,54
+North Providence,Senator in General Assembly District 15,,DEM,Herbert P. Weiss*,31
+North Providence,Senator in General Assembly District 17,,,Total,293
+North Providence,Senator in General Assembly District 17,,DEM,"John Douglas Barr, II",293
+North Providence,Senator in General Assembly District 22,,,Total,605
+North Providence,Senator in General Assembly District 22,,DEM,Stephen R. Archambault*,354
+North Providence,Senator in General Assembly District 22,,DEM,Melanie G. DuPont,251
+North Providence,Representative in General Assembly District 6,,,Total,230
+North Providence,Representative in General Assembly District 6,,DEM,Raymond A. Hull*,230
+North Providence,Representative in General Assembly District 54,,,Total,1037
+North Providence,Representative in General Assembly District 54,,DEM,William W. O&#39;Brien*,1037
+North Providence,Representative in General Assembly District 55,,,Total,1768
+North Providence,Representative in General Assembly District 55,,DEM,Arthur J. Corvese*,1768
+North Providence,Council District 1 North Providence,,,Total,1329
+North Providence,Council District 1 North Providence,,DEM,Steven A. Loporchio,819
+North Providence,Council District 1 North Providence,,DEM,"Mansuet J. Giusti, III*",510
+North Providence,School Committee District 2 North Providence,,,Total,1754
+North Providence,School Committee District 2 North Providence,,DEM,Roderick E. Da Silva*,922
+North Providence,School Committee District 2 North Providence,,DEM,Catarina Alexandra DaSilva,832
+North Providence,Senatorial District Committee District 4,,,Total,10441
+North Providence,Senatorial District Committee District 4,,DEM,Lisa M. Aceto*,1300
+North Providence,Senatorial District Committee District 4,,DEM,Stefano V. Famiglietti*,1296
+North Providence,Senatorial District Committee District 4,,DEM,Peter S. Mancini*,1186
+North Providence,Senatorial District Committee District 4,,DEM,Lisa M. Andoscia*,1169
+North Providence,Senatorial District Committee District 4,,DEM,Christopher R. Corsini*,1134
+North Providence,Senatorial District Committee District 4,,DEM,Nicole Marie Verdi*,1095
+North Providence,Senatorial District Committee District 4,,DEM,Robert J. Kilduff*,921
+North Providence,Senatorial District Committee District 4,,DEM,Clara A. Hardy,722
+North Providence,Senatorial District Committee District 4,,DEM,Eloise M. O&#39;Shea-Wyatt,667
+North Providence,Senatorial District Committee District 4,,DEM,Leonardo Martinez,509
+North Providence,Senatorial District Committee District 4,,DEM,Michael E. Bibeault,442
+North Providence,Senatorial District Committee District 22,,,Total,2403
+North Providence,Senatorial District Committee District 22,,DEM,Peter B. Simone*,368
+North Providence,Senatorial District Committee District 22,,DEM,Lawrence J. Mancini*,324
+North Providence,Senatorial District Committee District 22,,DEM,Pasquale A. Matteo*,301
+North Providence,Senatorial District Committee District 22,,DEM,S. Jean Cerroni*,298
+North Providence,Senatorial District Committee District 22,,DEM,Charles T. Jackvony*,294
+North Providence,Senatorial District Committee District 22,,DEM,Timothy F. Kane*,283
+North Providence,Senatorial District Committee District 22,,DEM,Mycala J. McKay,271
+North Providence,Senatorial District Committee District 22,,DEM,James K. McNelis*,264
+North Smithfield,Non-Partisan Town Administrator TOWN OF NORTH SMITHFIELD,,,Total,1270
+North Smithfield,Non-Partisan Town Administrator TOWN OF NORTH SMITHFIELD,,,Paul J. Zwolenski,524
+North Smithfield,Non-Partisan Town Administrator TOWN OF NORTH SMITHFIELD,,,Douglas B. Osier,385
+North Smithfield,Non-Partisan Town Administrator TOWN OF NORTH SMITHFIELD,,,Paul M. Jones,361
+Pawtucket,Senator in Congress,,,Total,5734
+Pawtucket,Senator in Congress,,DEM,John F. Reed*,5734
+Pawtucket,Representative in Congress District 1,,,Total,5878
+Pawtucket,Representative in Congress District 1,,DEM,David N. Cicilline*,5878
+Pawtucket,Senator in General Assembly District 8,,,Total,2112
+Pawtucket,Senator in General Assembly District 8,,DEM,Sandra C. Cano*,2112
+Pawtucket,Senator in General Assembly District 15,,,Total,2532
+Pawtucket,Senator in General Assembly District 15,,DEM,Meghan E. Kallman,1608
+Pawtucket,Senator in General Assembly District 15,,DEM,Herbert P. Weiss*,604
+Pawtucket,Senator in General Assembly District 15,,DEM,"Robert H. Morris, Jr.",320
+Pawtucket,Senator in General Assembly District 16,,,Total,392
+Pawtucket,Senator in General Assembly District 16,,DEM,Elizabeth A. Crowley*,215
+Pawtucket,Senator in General Assembly District 16,,DEM,Jonathon Acosta,139
+Pawtucket,Senator in General Assembly District 16,,DEM,Leslie Estrada,38
+Pawtucket,Senator in General Assembly District 18,,,Total,1072
+Pawtucket,Senator in General Assembly District 18,,DEM,Cynthia M. Mendes,602
+Pawtucket,Senator in General Assembly District 18,,DEM,"William J. Conley, Jr.*",470
+Pawtucket,Representative in General Assembly District 46,,,Total,64
+Pawtucket,Representative in General Assembly District 46,,DEM,Mary Ann Shallcross Smith,64
+Pawtucket,Representative in General Assembly District 58,,,Total,807
+Pawtucket,Representative in General Assembly District 58,,DEM,Carlos Eduardo Tobon,807
+Pawtucket,Representative in General Assembly District 59,,,Total,1381
+Pawtucket,Representative in General Assembly District 59,,DEM,Jean Philippe Barros*,1381
+Pawtucket,Representative in General Assembly District 60,,,Total,700
+Pawtucket,Representative in General Assembly District 60,,DEM,Karen Alzate*,700
+Pawtucket,Representative in General Assembly District 61,,,Total,1685
+Pawtucket,Representative in General Assembly District 61,,DEM,Leonela Felix,988
+Pawtucket,Representative in General Assembly District 61,,DEM,"Raymond H. Johnston, Jr.*",697
+Pawtucket,Representative in General Assembly District 62,,,Total,1106
+Pawtucket,Representative in General Assembly District 62,,DEM,Mary Duffy Messier*,1106
+Pawtucket,Mayor CITY OF PAWTUCKET,,,Total,6467
+Pawtucket,Mayor CITY OF PAWTUCKET,,DEM,Donald R. Grebien*,4234
+Pawtucket,Mayor CITY OF PAWTUCKET,,DEM,David F. Norton,2233
+Pawtucket,Council At-Large CITY OF PAWTUCKET,,,Total,16413
+Pawtucket,Council At-Large CITY OF PAWTUCKET,,DEM,Michael A. Araujo*,3325
+Pawtucket,Council At-Large CITY OF PAWTUCKET,,DEM,Elena Vasquez,3263
+Pawtucket,Council At-Large CITY OF PAWTUCKET,,DEM,Melissa L. DaRosa,3246
+Pawtucket,Council At-Large CITY OF PAWTUCKET,,DEM,"Albert Joseph Vitali, Jr.*",2604
+Pawtucket,Council At-Large CITY OF PAWTUCKET,,DEM,Agi F. Gai-Kah,2236
+Pawtucket,Council At-Large CITY OF PAWTUCKET,,DEM,Tarshire Battle,1739
+Pawtucket,Council District 1 Pawtucket,,,Total,1039
+Pawtucket,Council District 1 Pawtucket,,DEM,David P. Moran*,567
+Pawtucket,Council District 1 Pawtucket,,DEM,Crisolita D. Figueiredo,472
+Pawtucket,Council District 4 Pawtucket,,,Total,1214
+Pawtucket,Council District 4 Pawtucket,,DEM,Alexis C. Schuette,629
+Pawtucket,Council District 4 Pawtucket,,DEM,"John J. Barry, III*",585
+Pawtucket,Council District 5 Pawtucket,,,Total,940
+Pawtucket,Council District 5 Pawtucket,,DEM,Ama Mensah Amponsah*,471
+Pawtucket,Council District 5 Pawtucket,,DEM,Janie Lee Segui Rodriguez,469
+Pawtucket,Council District 6 Pawtucket,,,Total,1014
+Pawtucket,Council District 6 Pawtucket,,DEM,"Timothy P. Rudd, Jr.*",608
+Pawtucket,Council District 6 Pawtucket,,DEM,Marlena M. Stachowiak,406
+Pawtucket,Senatorial District Committee District 18,,,Total,5833
+Pawtucket,Senatorial District Committee District 18,,DEM,Emily N. Mercer*,702
+Pawtucket,Senatorial District Committee District 18,,DEM,Norma J. Conley*,651
+Pawtucket,Senatorial District Committee District 18,,DEM,Debra J. Cook*,647
+Pawtucket,Senatorial District Committee District 18,,DEM,Patricia Ann Scorpio*,606
+Pawtucket,Senatorial District Committee District 18,,DEM,Robin M. Bothelo*,595
+Pawtucket,Senatorial District Committee District 18,,DEM,Sharlene L. Damiani*,525
+Pawtucket,Senatorial District Committee District 18,,DEM,Joseph C. Knight*,495
+Pawtucket,Senatorial District Committee District 18,,DEM,Emily R. Walter,474
+Pawtucket,Senatorial District Committee District 18,,DEM,Christen D. Sherman,342
+Pawtucket,Senatorial District Committee District 18,,DEM,Gregory R. Greco,280
+Pawtucket,Senatorial District Committee District 18,,DEM,Jarrett R. McPhee,271
+Pawtucket,Senatorial District Committee District 18,,DEM,Lee G. Wilder,245
+Pawtucket,Ward Committee District 6 Pawtucket,,,Total,4385
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,"Timothy P. Rudd, Jr.*",623
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,Kathleen A. Brown*,583
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,Patricia R. Murray*,561
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,Lori J. Barden*,549
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,Patricia A. Dedora-St. Germain*,535
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,Marlena M. Stachowiak,529
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,Margaret-Mary Belliveau-Hovarth*,513
+Pawtucket,Ward Committee District 6 Pawtucket,,DEM,"William D. Vieira, Sr.*",492
+Portsmouth,Senator in Congress,,,Total,1358
+Portsmouth,Senator in Congress,,DEM,John F. Reed*,1358
+Portsmouth,Representative in Congress District 1,,,Total,1359
+Portsmouth,Representative in Congress District 1,,DEM,David N. Cicilline*,1359
+Portsmouth,Senator in General Assembly District 11,,,Total,1300
+Portsmouth,Senator in General Assembly District 11,,DEM,James Arthur Seveney*,1300
+Portsmouth,Representative in General Assembly District 71,,,Total,534
+Portsmouth,Representative in General Assembly District 71,,DEM,Michelle E. McGaw,419
+Portsmouth,Representative in General Assembly District 71,,DEM,"John G. Edwards, V*",115
+Portsmouth,Representative in General Assembly District 72,,,Total,944
+Portsmouth,Representative in General Assembly District 72,,DEM,Terri-Denise Cortvriend*,818
+Portsmouth,Representative in General Assembly District 72,,DEM,Christopher T. Semonelli,126
+Portsmouth,Representative District Committee District 71,,,Total,2209
+Portsmouth,Representative District Committee District 71,,DEM,Michelle E. McGaw,433
+Portsmouth,Representative District Committee District 71,,DEM,Anya R. Wallack,229
+Portsmouth,Representative District Committee District 71,,DEM,"John G. Edwards, V*",224
+Portsmouth,Representative District Committee District 71,,DEM,Amy J. Canario*,214
+Portsmouth,Representative District Committee District 71,,DEM,Maureen Evelyn Molloy Morrow,210
+Portsmouth,Representative District Committee District 71,,DEM,Dennis M. Canario*,194
+Portsmouth,Representative District Committee District 71,,DEM,Glenn Diana Sherman,194
+Portsmouth,Representative District Committee District 71,,DEM,Kimberley J. Waltz*,175
+Portsmouth,Representative District Committee District 71,,DEM,Brittany T. Edwards*,168
+Portsmouth,Representative District Committee District 71,,DEM,Christopher E. Goulart,168
+Providence,Senator in Congress,,,Total,9230
+Providence,Senator in Congress,,DEM,John F. Reed*,9230
+Providence,Representative in Congress District 1,,,Total,3802
+Providence,Representative in Congress District 1,,DEM,David N. Cicilline*,3802
+Providence,Representative in Congress District 2,,,Total,6477
+Providence,Representative in Congress District 2,,DEM,James R. Langevin*,4357
+Providence,Representative in Congress District 2,,DEM,Dylan Conley,2120
+Providence,Senator in General Assembly District 1,,,Total,2020
+Providence,Senator in General Assembly District 1,,DEM,Maryellen Goodwin*,1601
+Providence,Senator in General Assembly District 1,,DEM,Evan A. Lemoine,419
+Providence,Senator in General Assembly District 2,,,Total,782
+Providence,Senator in General Assembly District 2,,DEM,Ana B. Quezada*,782
+Providence,Senator in General Assembly District 4,,,Total,1091
+Providence,Senator in General Assembly District 4,,DEM,"Leonardo A. Cioe, Jr.",667
+Providence,Senator in General Assembly District 4,,DEM,Dominick J. Ruggerio*,424
+Providence,Senator in General Assembly District 5,,,Total,2951
+Providence,Senator in General Assembly District 5,,DEM,Samuel W. Bell,2139
+Providence,Senator in General Assembly District 5,,DEM,Jo-Ann Ryan,812
+Providence,Senator in General Assembly District 6,,,Total,2517
+Providence,Senator in General Assembly District 6,,DEM,Tiara T. Mack,1506
+Providence,Senator in General Assembly District 6,,DEM,Harold M. Metts*,1011
+Providence,Senator in General Assembly District 7,,,Total,973
+Providence,Senator in General Assembly District 7,,DEM,Frank A. Ciccone*,973
+Providence,Senator in General Assembly District 28,,,Total,42
+Providence,Senator in General Assembly District 28,,DEM,Joshua Miller*,42
+Providence,Representative in General Assembly District 1,,,Total,97
+Providence,Representative in General Assembly District 1,,DEM,Edith H. Ajello*,97
+Providence,Representative in General Assembly District 2,,,Total,425
+Providence,Representative in General Assembly District 2,,DEM,Christopher R. Blazejewski*,425
+Providence,Representative in General Assembly District 3,,,Total,758
+Providence,Representative in General Assembly District 3,,DEM,Nathan W. Biah,491
+Providence,Representative in General Assembly District 3,,DEM,Moira J. Walsh,267
+Providence,Representative in General Assembly District 4,,,Total,637
+Providence,Representative in General Assembly District 4,,DEM,Rebecca M. Kislak*,637
+Providence,Representative in General Assembly District 5,,,Total,795
+Providence,Representative in General Assembly District 5,,DEM,Marcia P. Ranglin-Vassell,795
+Providence,Representative in General Assembly District 6,,,Total,751
+Providence,Representative in General Assembly District 6,,DEM,Raymond A. Hull*,751
+Providence,Representative in General Assembly District 7,,,Total,1771
+Providence,Representative in General Assembly District 7,,DEM,David Morales,875
+Providence,Representative in General Assembly District 7,,DEM,Daniel P. McKiernan,493
+Providence,Representative in General Assembly District 7,,DEM,Angel Subervi*,403
+Providence,Representative in General Assembly District 8,,,Total,1219
+Providence,Representative in General Assembly District 8,,DEM,John J. Lombardi*,1098
+Providence,Representative in General Assembly District 8,,DEM,Darwin Castro,121
+Providence,Representative in General Assembly District 9,,,Total,712
+Providence,Representative in General Assembly District 9,,DEM,Anastasia P. Williams*,712
+Providence,Representative in General Assembly District 10,,,Total,130
+Providence,Representative in General Assembly District 10,,DEM,Scott A. Slater,130
+Providence,Representative in General Assembly District 11,,,Total,1006
+Providence,Representative in General Assembly District 11,,DEM,Grace Diaz*,730
+Providence,Representative in General Assembly District 11,,DEM,Laura Perez,276
+Providence,Representative in General Assembly District 12,,,Total,1046
+Providence,Representative in General Assembly District 12,,DEM,Jose F. Batista,589
+Providence,Representative in General Assembly District 12,,DEM,Carlos Cedeno,457
+Providence,Representative in General Assembly District 13,,,Total,886
+Providence,Representative in General Assembly District 13,,DEM,Ramon A. Perez,624
+Providence,Representative in General Assembly District 13,,DEM,Mario F. Mendez*,151
+Providence,Representative in General Assembly District 13,,DEM,Janice A. Falconer,111
+Providence,Representative in General Assembly District 14,,,Total,48
+Providence,Representative in General Assembly District 14,,DEM,Charlene Lima*,48
+Providence,Senatorial District Committee District 4,,,Total,4564
+Providence,Senatorial District Committee District 4,,DEM,Peter S. Mancini*,516
+Providence,Senatorial District Committee District 4,,DEM,Nicole Marie Verdi*,509
+Providence,Senatorial District Committee District 4,,DEM,Lisa M. Aceto*,483
+Providence,Senatorial District Committee District 4,,DEM,Lisa M. Andoscia*,473
+Providence,Senatorial District Committee District 4,,DEM,Clara A. Hardy,431
+Providence,Senatorial District Committee District 4,,DEM,Eloise M. O&#39;Shea-Wyatt,423
+Providence,Senatorial District Committee District 4,,DEM,Leonardo Martinez,393
+Providence,Senatorial District Committee District 4,,DEM,Robert J. Kilduff*,387
+Providence,Senatorial District Committee District 4,,DEM,Christopher R. Corsini*,348
+Providence,Senatorial District Committee District 4,,DEM,Stefano V. Famiglietti*,316
+Providence,Senatorial District Committee District 4,,DEM,Michael E. Bibeault,285
+Providence,Senatorial District Committee District 5,,,Total,8305
+Providence,Senatorial District Committee District 5,,DEM,Emilia L. DaSilva-Tavarez,1602
+Providence,Senatorial District Committee District 5,,DEM,Jacqueline Esther Goldman,1422
+Providence,Senatorial District Committee District 5,,DEM,Samantha D. Weiser,1397
+Providence,Senatorial District Committee District 5,,DEM,Paul V. Jabour,1373
+Providence,Senatorial District Committee District 5,,DEM,Nellie V. Goodlin,1328
+Providence,Senatorial District Committee District 5,,DEM,David R. Comerford,650
+Providence,Senatorial District Committee District 5,,DEM,James Edward Scott,533
+Providence,Representative District Committee District 5,,,Total,1856
+Providence,Representative District Committee District 5,,DEM,Raphael Olawale Okelola,506
+Providence,Representative District Committee District 5,,DEM,Kathleen Forte,474
+Providence,Representative District Committee District 5,,DEM,Leslie A. Parrillo*,466
+Providence,Representative District Committee District 5,,DEM,Aria E. DiMeo*,410
+Providence,Representative District Committee District 7,,,Total,3275
+Providence,Representative District Committee District 7,,DEM,Joanne M. Giannini*,1022
+Providence,Representative District Committee District 7,,DEM,Curtis R. Pouliot-Alvarez*,687
+Providence,Representative District Committee District 7,,DEM,Nancylee Dowd*,639
+Providence,Representative District Committee District 7,,DEM,Bridget E. McKiernan,601
+Providence,Representative District Committee District 7,,DEM,"Theodore M. Newcomer, Jr.",326
+Providence,Representative District Committee District 9,,,Total,1550
+Providence,Representative District Committee District 9,,DEM,Claudette C. Smith*,493
+Providence,Representative District Committee District 9,,DEM,Lesley H. Bunnell*,430
+Providence,Representative District Committee District 9,,DEM,Obeida Papp,320
+Providence,Representative District Committee District 9,,DEM,"Raymond J. Sullivan, Jr.*",307
+Providence,Senator in Congress,,,Total,207
+Providence,Senator in Congress,,REP,Allen R. Waters,207
+Providence,Representative in Congress District 2,,,Total,216
+Providence,Representative in Congress District 2,,REP,Robert B. Lancia*,139
+Providence,Representative in Congress District 2,,REP,Donald Frederick Robbio,77
+Providence,Representative in General Assembly District 5,,,Total,19
+Providence,Representative in General Assembly District 5,,REP,Ronald F. Iacobbo*,19
+Richmond,Senator in Congress,,,Total,369
+Richmond,Senator in Congress,,DEM,John F. Reed*,369
+Richmond,Representative in Congress District 2,,,Total,383
+Richmond,Representative in Congress District 2,,DEM,James R. Langevin*,258
+Richmond,Representative in Congress District 2,,DEM,Dylan Conley,125
+Richmond,Senator in General Assembly District 34,,,Total,356
+Richmond,Senator in General Assembly District 34,,DEM,Jennifer C. Douglas,356
+Richmond,Representative in General Assembly District 39,,,Total,363
+Richmond,Representative in General Assembly District 39,,DEM,Megan L. Cotter*,363
+Richmond,Senator in Congress,,,Total,131
+Richmond,Senator in Congress,,REP,Allen R. Waters,131
+Richmond,Representative in Congress District 2,,,Total,149
+Richmond,Representative in Congress District 2,,REP,Robert B. Lancia*,126
+Richmond,Representative in Congress District 2,,REP,Donald Frederick Robbio,23
+Richmond,Senator in General Assembly District 34,,,Total,139
+Richmond,Senator in General Assembly District 34,,REP,Elaine J. Morgan*,139
+Richmond,Representative in General Assembly District 39,,,Total,140
+Richmond,Representative in General Assembly District 39,,REP,Justin K. Price*,140
+Scituate,Senator in Congress,,,Total,381
+Scituate,Senator in Congress,,DEM,John F. Reed*,381
+Scituate,Representative in Congress District 2,,,Total,419
+Scituate,Representative in Congress District 2,,DEM,James R. Langevin*,311
+Scituate,Representative in Congress District 2,,DEM,Dylan Conley,108
+Scituate,Representative in General Assembly District 41,,,Total,419
+Scituate,Representative in General Assembly District 41,,DEM,Pamela Carosi*,358
+Scituate,Representative in General Assembly District 41,,DEM,Giuseppe Mattiello,61
+Scituate,Senator in Congress,,,Total,220
+Scituate,Senator in Congress,,REP,Allen R. Waters,220
+Scituate,Representative in Congress District 2,,,Total,241
+Scituate,Representative in Congress District 2,,REP,Robert B. Lancia*,175
+Scituate,Representative in Congress District 2,,REP,Donald Frederick Robbio,66
+Scituate,Senator in General Assembly District 21,,,Total,220
+Scituate,Senator in General Assembly District 21,,REP,Gordon E. Rogers*,220
+Scituate,Representative in General Assembly District 41,,,Total,231
+Scituate,Representative in General Assembly District 41,,REP,Robert J. Quattrocchi*,231
+Smithfield,Senator in Congress,,,Total,1378
+Smithfield,Senator in Congress,,DEM,John F. Reed*,1378
+Smithfield,Representative in Congress District 1,,,Total,1337
+Smithfield,Representative in Congress District 1,,DEM,David N. Cicilline*,1337
+Smithfield,Senator in General Assembly District 22,,,Total,1607
+Smithfield,Senator in General Assembly District 22,,DEM,Stephen R. Archambault*,958
+Smithfield,Senator in General Assembly District 22,,DEM,Melanie G. DuPont,649
+Smithfield,Representative in General Assembly District 44,,,Total,681
+Smithfield,Representative in General Assembly District 44,,DEM,Gregory J. Costantino*,681
+Smithfield,Representative in General Assembly District 53,,,Total,628
+Smithfield,Representative in General Assembly District 53,,DEM,Bernard A. Hawkins*,628
+Smithfield,School Committee TOWN OF SMITHFIELD,,,Total,2744
+Smithfield,School Committee TOWN OF SMITHFIELD,,DEM,Anthony J. Torregrossa*,1005
+Smithfield,School Committee TOWN OF SMITHFIELD,,DEM,Benjamin W. Caisse,881
+Smithfield,School Committee TOWN OF SMITHFIELD,,DEM,Jeffrey R. Angelo*,858
+Smithfield,Senatorial District Committee District 22,,,Total,7844
+Smithfield,Senatorial District Committee District 22,,DEM,Timothy F. Kane*,1119
+Smithfield,Senatorial District Committee District 22,,DEM,S. Jean Cerroni*,1050
+Smithfield,Senatorial District Committee District 22,,DEM,James K. McNelis*,998
+Smithfield,Senatorial District Committee District 22,,DEM,Pasquale A. Matteo*,971
+Smithfield,Senatorial District Committee District 22,,DEM,Lawrence J. Mancini*,965
+Smithfield,Senatorial District Committee District 22,,DEM,Charles T. Jackvony*,957
+Smithfield,Senatorial District Committee District 22,,DEM,Peter B. Simone*,919
+Smithfield,Senatorial District Committee District 22,,DEM,Mycala J. McKay,865
+South Kingstown,Senator in Congress,,,Total,4034
+South Kingstown,Senator in Congress,,DEM,John F. Reed*,4034
+South Kingstown,Representative in Congress District 2,,,Total,4376
+South Kingstown,Representative in Congress District 2,,DEM,James R. Langevin*,2898
+South Kingstown,Representative in Congress District 2,,DEM,Dylan Conley,1478
+South Kingstown,Senator in General Assembly District 35,,,Total,119
+South Kingstown,Senator in General Assembly District 35,,DEM,Bridget G. Valverde*,119
+South Kingstown,Senator in General Assembly District 37,,,Total,3947
+South Kingstown,Senator in General Assembly District 37,,DEM,Virginia S. Sosnowski*,2384
+South Kingstown,Senator in General Assembly District 37,,DEM,Maggie A. Kain,1563
+South Kingstown,Representative in General Assembly District 33,,,Total,907
+South Kingstown,Representative in General Assembly District 33,,DEM,Carol Hagan McEntee*,907
+South Kingstown,Representative in General Assembly District 34,,,Total,1173
+South Kingstown,Representative in General Assembly District 34,,DEM,Teresa A. Tanzi*,861
+South Kingstown,Representative in General Assembly District 34,,DEM,Gina M. Giramma,312
+South Kingstown,Representative in General Assembly District 35,,,Total,1561
+South Kingstown,Representative in General Assembly District 35,,DEM,Kathleen A. Fogarty*,1182
+South Kingstown,Representative in General Assembly District 35,,DEM,Spencer E. Dickinson,379
+South Kingstown,Town Council TOWN OF SOUTH KINGSTOWN,,,Total,15235
+South Kingstown,Town Council TOWN OF SOUTH KINGSTOWN,,DEM,Abel G. Collins*,2964
+South Kingstown,Town Council TOWN OF SOUTH KINGSTOWN,,DEM,Deborah J. Kelso*,2686
+South Kingstown,Town Council TOWN OF SOUTH KINGSTOWN,,DEM,Rory H. McEntee*,2672
+South Kingstown,Town Council TOWN OF SOUTH KINGSTOWN,,DEM,Jessica L. Rose*,2505
+South Kingstown,Town Council TOWN OF SOUTH KINGSTOWN,,DEM,Deborah D. Bergner,2280
+South Kingstown,Town Council TOWN OF SOUTH KINGSTOWN,,DEM,Edward Myszak*,2128
+South Kingstown,School Committee TOWN OF SOUTH KINGSTOWN,,,Total,13630
+South Kingstown,School Committee TOWN OF SOUTH KINGSTOWN,,DEM,Paula J. Whitford*,2669
+South Kingstown,School Committee TOWN OF SOUTH KINGSTOWN,,DEM,Christie L. Fish*,2454
+South Kingstown,School Committee TOWN OF SOUTH KINGSTOWN,,DEM,Melissa A. Boyd,2311
+South Kingstown,School Committee TOWN OF SOUTH KINGSTOWN,,DEM,Michelle Brousseau,2208
+South Kingstown,School Committee TOWN OF SOUTH KINGSTOWN,,DEM,Stephanie R. Canter*,2093
+South Kingstown,School Committee TOWN OF SOUTH KINGSTOWN,,DEM,Cadence L. Hansen,1895
+South Kingstown,Senatorial District Committee District 37,,,Total,17574
+South Kingstown,Senatorial District Committee District 37,,DEM,Virginia S. Sosnowski*,2524
+South Kingstown,Senatorial District Committee District 37,,DEM,Deborah J. Kelso*,1960
+South Kingstown,Senatorial District Committee District 37,,DEM,Maggie A. Kain,1840
+South Kingstown,Senatorial District Committee District 37,,DEM,Terrence G. Simpson*,1404
+South Kingstown,Senatorial District Committee District 37,,DEM,Leanne M. Peckham*,1375
+South Kingstown,Senatorial District Committee District 37,,DEM,John M. Rose*,1331
+South Kingstown,Senatorial District Committee District 37,,DEM,Patricia Breslin Filippo*,1278
+South Kingstown,Senatorial District Committee District 37,,DEM,Kimberley H. Gaffett*,1142
+South Kingstown,Senatorial District Committee District 37,,DEM,Sarah E. Markey,1089
+South Kingstown,Senatorial District Committee District 37,,DEM,Emily R. Cotter,959
+South Kingstown,Senatorial District Committee District 37,,DEM,Tara M. Apperson,670
+South Kingstown,Senatorial District Committee District 37,,DEM,Judith A. Kain,597
+South Kingstown,Senatorial District Committee District 37,,DEM,"Robert W. Widell, Jr.",566
+South Kingstown,Senatorial District Committee District 37,,DEM,Torrey R. Martin,428
+South Kingstown,Senatorial District Committee District 37,,DEM,Joshua T. Maldonado,411
+South Kingstown,Senator in Congress,,,Total,328
+South Kingstown,Senator in Congress,,REP,Allen R. Waters,328
+South Kingstown,Representative in Congress District 2,,,Total,348
+South Kingstown,Representative in Congress District 2,,REP,Robert B. Lancia*,242
+South Kingstown,Representative in Congress District 2,,REP,Donald Frederick Robbio,106
+South Kingstown,Senator in General Assembly District 35,,,Total,12
+South Kingstown,Senator in General Assembly District 35,,REP,Charles P. Callanan*,12
+South Kingstown,Senator in General Assembly District 37,,,Total,298
+South Kingstown,Senator in General Assembly District 37,,REP,David A. Tacey*,298
+South Kingstown,Senator in General Assembly District 38,,,Total,30
+South Kingstown,Senator in General Assembly District 38,,REP,Dennis L. Algiere*,30
+South Kingstown,Representative in General Assembly District 36,,,Total,56
+South Kingstown,Representative in General Assembly District 36,,REP,Blake A. Filippi*,56
+Tiverton,Senator in Congress,,,Total,390
+Tiverton,Senator in Congress,,DEM,John F. Reed*,390
+Tiverton,Representative in Congress District 1,,,Total,385
+Tiverton,Representative in Congress District 1,,DEM,David N. Cicilline*,385
+Tiverton,Senator in General Assembly District 12,,,Total,365
+Tiverton,Senator in General Assembly District 12,,DEM,Louis P. DiPalma*,365
+Tiverton,Representative in General Assembly District 71,,,Total,452
+Tiverton,Representative in General Assembly District 71,,DEM,Michelle E. McGaw,319
+Tiverton,Representative in General Assembly District 71,,DEM,"John G. Edwards, V*",133
+Tiverton,Representative District Committee District 71,,,Total,1772
+Tiverton,Representative District Committee District 71,,DEM,Michelle E. McGaw,351
+Tiverton,Representative District Committee District 71,,DEM,Maureen Evelyn Molloy Morrow,202
+Tiverton,Representative District Committee District 71,,DEM,Anya R. Wallack,195
+Tiverton,Representative District Committee District 71,,DEM,"John G. Edwards, V*",181
+Tiverton,Representative District Committee District 71,,DEM,Christopher E. Goulart,175
+Tiverton,Representative District Committee District 71,,DEM,Glenn Diana Sherman,164
+Tiverton,Representative District Committee District 71,,DEM,Dennis M. Canario*,141
+Tiverton,Representative District Committee District 71,,DEM,Kimberley J. Waltz*,131
+Tiverton,Representative District Committee District 71,,DEM,Amy J. Canario*,123
+Tiverton,Representative District Committee District 71,,DEM,Brittany T. Edwards*,109
+Warwick,Senator in Congress,,,Total,8328
+Warwick,Senator in Congress,,DEM,John F. Reed*,8328
+Warwick,Representative in Congress District 2,,,Total,9276
+Warwick,Representative in Congress District 2,,DEM,James R. Langevin*,6351
+Warwick,Representative in Congress District 2,,DEM,Dylan Conley,2925
+Warwick,Senator in General Assembly District 29,,,Total,3355
+Warwick,Senator in General Assembly District 29,,DEM,Michael J. McCaffrey*,1952
+Warwick,Senator in General Assembly District 29,,DEM,Jennifer T. Rourke,1403
+Warwick,Senator in General Assembly District 30,,,Total,2726
+Warwick,Senator in General Assembly District 30,,DEM,Jeanine Calkin*,1509
+Warwick,Senator in General Assembly District 30,,DEM,Mark P. McKenney,1217
+Warwick,Senator in General Assembly District 31,,,Total,3292
+Warwick,Senator in General Assembly District 31,,DEM,Kendra Anderson,1016
+Warwick,Senator in General Assembly District 31,,DEM,Steve Merolla*,852
+Warwick,Senator in General Assembly District 31,,DEM,Brian S. Dunckley,771
+Warwick,Senator in General Assembly District 31,,DEM,Michael F. Mita,653
+Warwick,Representative in General Assembly District 19,,,Total,1954
+Warwick,Representative in General Assembly District 19,,DEM,Joseph McNamara*,1230
+Warwick,Representative in General Assembly District 19,,DEM,Stuart A. Wilson,724
+Warwick,Representative in General Assembly District 20,,,Total,965
+Warwick,Representative in General Assembly District 20,,DEM,David A. Bennett*,965
+Warwick,Representative in General Assembly District 21,,,Total,1214
+Warwick,Representative in General Assembly District 21,,DEM,Camille F. Vella-Wilkinson*,1214
+Warwick,Representative in General Assembly District 22,,,Total,1022
+Warwick,Representative in General Assembly District 22,,DEM,"Joseph J. Solomon, Jr.*",1022
+Warwick,Representative in General Assembly District 23,,,Total,1103
+Warwick,Representative in General Assembly District 23,,DEM,K. Joseph Shekarchi*,1103
+Warwick,Representative in General Assembly District 24,,,Total,1591
+Warwick,Representative in General Assembly District 24,,DEM,Evan P. Shanley,1591
+Warwick,Representative in General Assembly District 26,,,Total,84
+Warwick,Representative in General Assembly District 26,,DEM,James B. Jackson*,84
+Warwick,Representative in General Assembly District 27,,,Total,159
+Warwick,Representative in General Assembly District 27,,DEM,Patricia A. Serpa*,89
+Warwick,Representative in General Assembly District 27,,DEM,Nicholas E. Delmenico,70
+Warwick,Mayor CITY OF WARWICK,,,Total,9007
+Warwick,Mayor CITY OF WARWICK,,DEM,Joseph J. Solomon*,6350
+Warwick,Mayor CITY OF WARWICK,,DEM,Carel Callahan Bainum,2657
+Warwick,Council Ward 1 Warwick,,,Total,1567
+Warwick,Council Ward 1 Warwick,,DEM,William A. Foley*,927
+Warwick,Council Ward 1 Warwick,,DEM,Richard K. Corley,640
+Warwick,Council Ward 8 Warwick,,,Total,884
+Warwick,Council Ward 8 Warwick,,DEM,Anthony E. Sinapi*,508
+Warwick,Council Ward 8 Warwick,,DEM,Dan Elliott,376
+Warwick,Council Ward 9 Warwick,,,Total,1333
+Warwick,Council Ward 9 Warwick,,DEM,Vincent J. Gebhart*,761
+Warwick,Council Ward 9 Warwick,,DEM,Zachary A. Colon,572
+Warwick,Senatorial District Committee District 29,,,Total,11619
+Warwick,Senatorial District Committee District 29,,DEM,John T. McCaffrey*,1871
+Warwick,Senatorial District Committee District 29,,DEM,Nancy M. Sherrill*,1708
+Warwick,Senatorial District Committee District 29,,DEM,Irene A. Livsey*,1687
+Warwick,Senatorial District Committee District 29,,DEM,Michelle O. Komar*,1609
+Warwick,Senatorial District Committee District 29,,DEM,Christopher E. Friel*,1534
+Warwick,Senatorial District Committee District 29,,DEM,Thomas A. Rourke,1333
+Warwick,Senatorial District Committee District 29,,DEM,Capri C. Catanzaro,1075
+Warwick,Senatorial District Committee District 29,,DEM,Jordan C. Goyette,802
+Warwick,Senatorial District Committee District 30,,,Total,10480
+Warwick,Senatorial District Committee District 30,,DEM,Jennifer Siciliano*,1321
+Warwick,Senatorial District Committee District 30,,DEM,Daniel A. Calkin*,1315
+Warwick,Senatorial District Committee District 30,,DEM,Mary E. Preziosi*,1178
+Warwick,Senatorial District Committee District 30,,DEM,Pearl K. Holloway*,1144
+Warwick,Senatorial District Committee District 30,,DEM,Lorianne M. Charron*,1118
+Warwick,Senatorial District Committee District 30,,DEM,Leslie Walaska Baxter,942
+Warwick,Senatorial District Committee District 30,,DEM,David E. Revens,871
+Warwick,Senatorial District Committee District 30,,DEM,Susan J. Martins-Phipps,842
+Warwick,Senatorial District Committee District 30,,DEM,"Robert C. Baxter, Jr.",631
+Warwick,Senatorial District Committee District 30,,DEM,William A. Muto,622
+Warwick,Senatorial District Committee District 30,,DEM,Hithenias Merlino,496
+Warwick,City Committee Ward 5 Warwick,,,Total,4688
+Warwick,City Committee Ward 5 Warwick,,DEM,Edgar N. Ladouceur*,576
+Warwick,City Committee Ward 5 Warwick,,DEM,Patricia J. Hayes Gomm*,492
+Warwick,City Committee Ward 5 Warwick,,DEM,Robert M. Farrell*,417
+Warwick,City Committee Ward 5 Warwick,,DEM,Michael R. Cook*,376
+Warwick,City Committee Ward 5 Warwick,,DEM,George W. Shuster*,370
+Warwick,City Committee Ward 5 Warwick,,DEM,"Michael R. Riccitelli, Sr.*",369
+Warwick,City Committee Ward 5 Warwick,,DEM,Richard A. Leandre*,350
+Warwick,City Committee Ward 5 Warwick,,DEM,Diane L. Riccitelli,344
+Warwick,City Committee Ward 5 Warwick,,DEM,"William R. Bernard, Sr.*",314
+Warwick,City Committee Ward 5 Warwick,,DEM,Joseph C. Stanelun*,294
+Warwick,City Committee Ward 5 Warwick,,DEM,Mary E. Preziosi,280
+Warwick,City Committee Ward 5 Warwick,,DEM,Debra A. Quintero,278
+Warwick,City Committee Ward 5 Warwick,,DEM,Gerald Carbone,228
+Warwick,City Committee Ward 9 Warwick,,,Total,7093
+Warwick,City Committee Ward 9 Warwick,,DEM,Zachary A. Colon,731
+Warwick,City Committee Ward 9 Warwick,,DEM,Vincent J. Gebhart,678
+Warwick,City Committee Ward 9 Warwick,,DEM,Jillian L. Gebhart,619
+Warwick,City Committee Ward 9 Warwick,,DEM,Joy S. Bianco,591
+Warwick,City Committee Ward 9 Warwick,,DEM,Judith L. Zimmer,547
+Warwick,City Committee Ward 9 Warwick,,DEM,Kate E. Maccarone,543
+Warwick,City Committee Ward 9 Warwick,,DEM,Tricia A. Colon,527
+Warwick,City Committee Ward 9 Warwick,,DEM,Gina Dei Simonelli,516
+Warwick,City Committee Ward 9 Warwick,,DEM,Sara R. Dempsey,515
+Warwick,City Committee Ward 9 Warwick,,DEM,Julia H. Sharma Mathias,465
+Warwick,City Committee Ward 9 Warwick,,DEM,Matthew A. Resnick,422
+Warwick,City Committee Ward 9 Warwick,,DEM,Joseph C. Coffey,396
+Warwick,City Committee Ward 9 Warwick,,DEM,Nicholas F. Hickey,285
+Warwick,City Committee Ward 9 Warwick,,DEM,Charles J. Muller,258
+Warwick,Senator in Congress,,,Total,1224
+Warwick,Senator in Congress,,REP,Allen R. Waters,1224
+Warwick,Representative in Congress District 2,,,Total,1310
+Warwick,Representative in Congress District 2,,REP,Robert B. Lancia*,911
+Warwick,Representative in Congress District 2,,REP,Donald Frederick Robbio,399
+Warwick,Senator in General Assembly District 29,,,Total,399
+Warwick,Senator in General Assembly District 29,,REP,Jean E. Trafford*,399
+Warwick,Senator in General Assembly District 31,,,Total,482
+Warwick,Senator in General Assembly District 31,,REP,Scott M. Zambarano*,389
+Warwick,Senator in General Assembly District 31,,REP,John P. Silvaggio,93
+Warwick,Representative in General Assembly District 21,,,Total,198
+Warwick,Representative in General Assembly District 21,,REP,Ronald A. Loparto,198
+Warwick,Representative in General Assembly District 26,,,Total,27
+Warwick,Representative in General Assembly District 26,,REP,Patricia L. Morgan*,27
+West Greenwich,Senator in Congress,,,Total,224
+West Greenwich,Senator in Congress,,DEM,John F. Reed*,224
+West Greenwich,Representative in Congress District 2,,,Total,241
+West Greenwich,Representative in Congress District 2,,DEM,James R. Langevin*,176
+West Greenwich,Representative in Congress District 2,,DEM,Dylan Conley,65
+West Greenwich,Senator in General Assembly District 33,,,Total,109
+West Greenwich,Senator in General Assembly District 33,,DEM,Leonidas P. Raptakis*,109
+West Greenwich,Senator in General Assembly District 34,,,Total,41
+West Greenwich,Senator in General Assembly District 34,,DEM,Jennifer C. Douglas,41
+West Greenwich,Representative in General Assembly District 30,,,Total,51
+West Greenwich,Representative in General Assembly District 30,,DEM,Justine A. Caldwell*,51
+West Greenwich,Senator in Congress,,,Total,138
+West Greenwich,Senator in Congress,,REP,Allen R. Waters,138
+West Greenwich,Representative in Congress District 2,,,Total,152
+West Greenwich,Representative in Congress District 2,,REP,Robert B. Lancia*,123
+West Greenwich,Representative in Congress District 2,,REP,Donald Frederick Robbio,29
+West Greenwich,Senator in General Assembly District 21,,,Total,51
+West Greenwich,Senator in General Assembly District 21,,REP,Gordon E. Rogers*,51
+West Greenwich,Senator in General Assembly District 34,,,Total,21
+West Greenwich,Senator in General Assembly District 34,,REP,Elaine J. Morgan*,21
+West Greenwich,Representative in General Assembly District 29,,,Total,110
+West Greenwich,Representative in General Assembly District 29,,REP,Sherry Roberts*,110
+West Greenwich,Representative in General Assembly District 30,,,Total,38
+West Greenwich,Representative in General Assembly District 30,,REP,Antonio Giarrusso*,38
+West Warwick,Senator in Congress,,,Total,2043
+West Warwick,Senator in Congress,,DEM,John F. Reed*,2043
+West Warwick,Representative in Congress District 2,,,Total,2245
+West Warwick,Representative in Congress District 2,,DEM,James R. Langevin*,1592
+West Warwick,Representative in Congress District 2,,DEM,Dylan Conley,653
+West Warwick,Senator in General Assembly District 9,,,Total,2172
+West Warwick,Senator in General Assembly District 9,,DEM,John P. Burke,1106
+West Warwick,Senator in General Assembly District 9,,DEM,Geoffrey E. Rousselle*,1066
+West Warwick,Senator in General Assembly District 27,,,Total,79
+West Warwick,Senator in General Assembly District 27,,DEM,Hanna M. Gallo*,79
+West Warwick,Representative in General Assembly District 25,,,Total,535
+West Warwick,Representative in General Assembly District 25,,DEM,Thomas E. Noret*,535
+West Warwick,Representative in General Assembly District 26,,,Total,584
+West Warwick,Representative in General Assembly District 26,,DEM,James B. Jackson*,584
+West Warwick,Representative in General Assembly District 27,,,Total,1011
+West Warwick,Representative in General Assembly District 27,,DEM,Patricia A. Serpa*,733
+West Warwick,Representative in General Assembly District 27,,DEM,Nicholas E. Delmenico,278
+West Warwick,Senator in Congress,,,Total,414
+West Warwick,Senator in Congress,,REP,Allen R. Waters,414
+West Warwick,Representative in Congress District 2,,,Total,443
+West Warwick,Representative in Congress District 2,,REP,Robert B. Lancia*,276
+West Warwick,Representative in Congress District 2,,REP,Donald Frederick Robbio,167
+West Warwick,Senator in General Assembly District 9,,,Total,384
+West Warwick,Senator in General Assembly District 9,,REP,Jeffery L. Kozlin*,384
+West Warwick,Senator in General Assembly District 27,,,Total,27
+West Warwick,Senator in General Assembly District 27,,REP,Pat V. Cortellessa*,27
+West Warwick,Representative in General Assembly District 26,,,Total,161
+West Warwick,Representative in General Assembly District 26,,REP,Patricia L. Morgan*,161
+Westerly,Senator in Congress,,,Total,1022
+Westerly,Senator in Congress,,DEM,John F. Reed*,1022
+Westerly,Representative in Congress District 2,,,Total,1098
+Westerly,Representative in Congress District 2,,DEM,James R. Langevin*,845
+Westerly,Representative in Congress District 2,,DEM,Dylan Conley,253
+Westerly,Representative in General Assembly District 37,,,Total,620
+Westerly,Representative in General Assembly District 37,,DEM,Samuel A. Azzinaro*,620
+Westerly,Representative in General Assembly District 38,,,Total,336
+Westerly,Representative in General Assembly District 38,,DEM,Brian Patrick Kennedy*,224
+Westerly,Representative in General Assembly District 38,,DEM,Miguel J. Torres,112
+Westerly,Senator in Congress,,,Total,217
+Westerly,Senator in Congress,,REP,Allen R. Waters,217
+Westerly,Representative in Congress District 2,,,Total,224
+Westerly,Representative in Congress District 2,,REP,Robert B. Lancia*,163
+Westerly,Representative in Congress District 2,,REP,Donald Frederick Robbio,61
+Westerly,Senator in General Assembly District 38,,,Total,223
+Westerly,Senator in General Assembly District 38,,REP,Dennis L. Algiere*,223
+Westerly,Representative in General Assembly District 36,,,Total,23
+Westerly,Representative in General Assembly District 36,,REP,Blake A. Filippi*,23
+Westerly,Representative in General Assembly District 38,,,Total,55
+Westerly,Representative in General Assembly District 38,,REP,"Donald J. Kohlman, II*",55
+Woonsocket,Senator in Congress,,,Total,653
+Woonsocket,Senator in Congress,,DEM,John F. Reed*,653
+Woonsocket,Representative in Congress District 1,,,Total,673
+Woonsocket,Representative in Congress District 1,,DEM,David N. Cicilline*,673
+Woonsocket,Senator in General Assembly District 20,,,Total,409
+Woonsocket,Senator in General Assembly District 20,,DEM,Roger A. Picard*,409
+Woonsocket,Senator in General Assembly District 24,,,Total,259
+Woonsocket,Senator in General Assembly District 24,,DEM,Melissa A. Murray*,259
+Woonsocket,Representative in General Assembly District 49,,,Total,13
+Woonsocket,Representative in General Assembly District 49,,DEM,Steven J. Lima,13
+Woonsocket,Representative in General Assembly District 50,,,Total,356
+Woonsocket,Representative in General Assembly District 50,,DEM,Stephen M. Casey*,356
+Woonsocket,Representative in General Assembly District 51,,,Total,263
+Woonsocket,Representative in General Assembly District 51,,DEM,Robert D. Phillips,263
+Woonsocket,Senatorial District Committee District 20,,,Total,2264
+Woonsocket,Senatorial District Committee District 20,,DEM,Caitlyn L. Picard*,336
+Woonsocket,Senatorial District Committee District 20,,DEM,Debra A. LeClerc*,285
+Woonsocket,Senatorial District Committee District 20,,DEM,Lisa M. Mencucci*,284
+Woonsocket,Senatorial District Committee District 20,,DEM,Leslie A. Page,277
+Woonsocket,Senatorial District Committee District 20,,DEM,Jeanne C. DeBroisse*,276
+Woonsocket,Senatorial District Committee District 20,,DEM,"Angelo A. Mencucci, Jr.*",224
+Woonsocket,Senatorial District Committee District 20,,DEM,Douglas E. Connell*,223
+Woonsocket,Senatorial District Committee District 20,,DEM,Johnathan D. Berard,198
+Woonsocket,Senatorial District Committee District 20,,DEM,Nathan R. Carpenter,161
+Woonsocket,Representative District Committee District 50,,,Total,1018
+Woonsocket,Representative District Committee District 50,,DEM,Christopher M. Dubois*,233
+Woonsocket,Representative District Committee District 50,,DEM,Jeannine A. Giguere-Gagnon,188
+Woonsocket,Representative District Committee District 50,,DEM,Brian J. Thompson*,172
+Woonsocket,Representative District Committee District 50,,DEM,Charmaine Webster,163
+Woonsocket,Representative District Committee District 50,,DEM,"John R. Monse, Jr.*",152
+Woonsocket,Representative District Committee District 50,,DEM,Vaughan G. Miller,110

--- a/converter.py
+++ b/converter.py
@@ -2,7 +2,7 @@ import re
 import csv
 
 def convert():
-    with open("20201103__ri__general__precinct.csv", "wt") as csvfile:
+    with open("20200908__ri__primary__precinct.csv", "wt") as csvfile:
         w = csv.writer(csvfile)
         w.writerow(['office', 'district', 'candidate', 'party', 'precinct', 'votes', 'absentee_votes'])
         for line in get_lines():
@@ -98,7 +98,7 @@ def party_shortener(long):
         return ""
 
 def get_lines():
-    with open("rigen2020l.asc") as f:
+    with open("ripri2020l.asc") as f:
         return f.readlines()
 
 convert()

--- a/parser.py
+++ b/parser.py
@@ -11,13 +11,14 @@ results = []
 for town in towns:
     url = "https://rigov.s3.amazonaws.com/election/results/2020/statewide_primary/%s.json" % town.lower().replace(' ','_')
     r = requests.get(url)
-    contests = r.json()['contests']
-    for contest in contests:
-        office = contest['name']
-        total_votes = contest['total_votes']
-        results.append([town, office, None, None, 'Total', total_votes])
-        for candidate in contest['candidates']:
-            results.append([town, office, None, candidate['party_code'], candidate['name'], candidate['votes']])
+    if r.status_code == 200:
+        contests = r.json()['contests']
+        for contest in contests:
+            office = contest['name']
+            total_votes = contest['total_votes']
+            results.append([town, office, None, None, 'Total', total_votes])
+            for candidate in contest['candidates']:
+                results.append([town, office, None, candidate['party_code'], candidate['name'], candidate['votes']])
 
 with open("20200908__ri__primary__town.csv", "wt") as csvfile:
     w = csv.writer(csvfile)

--- a/parser.py
+++ b/parser.py
@@ -9,7 +9,7 @@ towns = ['Barrington','Bristol','Burrillville','Central Falls','Charlestown','Co
 results = []
 
 for town in towns:
-    url = "https://rigov.s3.amazonaws.com/election/results/2020/general_election/%s.json" % town.lower().replace(' ','_')
+    url = "https://rigov.s3.amazonaws.com/election/results/2020/statewide_primary/%s.json" % town.lower().replace(' ','_')
     r = requests.get(url)
     contests = r.json()['contests']
     for contest in contests:
@@ -19,8 +19,7 @@ for town in towns:
         for candidate in contest['candidates']:
             results.append([town, office, None, candidate['party_code'], candidate['name'], candidate['votes']])
 
-
-with open("20201103__ri__general__town.csv", "wt") as csvfile:
+with open("20200908__ri__primary__town.csv", "wt") as csvfile:
     w = csv.writer(csvfile)
     w.writerow(['county', 'office', 'district', 'party', 'candidate', 'votes'])
     w.writerows(results)


### PR DESCRIPTION
This data is from https://www.ri.gov/election/results/2020/statewide_primary/data/
The csv files were created by running `parser.py` and then `converter.py`.

Note: In Rhode Island's 2020 September primary, three municipalities did not hold primaries: Barrington, Warren and Lincoln. Therefore, there is no data from those communities in that election.
