### PR TITLE
Bump version of format tests

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v0.1.0
+        ref: v1.0.0
         path: format_tests
 
     - name: Run format tests


### PR DESCRIPTION
This updates the format tests to version [1.0.0](https://github.com/openelections/openelections-format-tests/releases/tag/v1.0.0).