### PR TITLE
converter: narrow bare except to IndexError

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -76,7 +76,7 @@ def district_shortener(long):
     if long:
         try:
             num = re.findall('\d+', long)[0]
-        except:
+        except IndexError:
             num = None
     else:
         num = ''


### PR DESCRIPTION
flake8 E722. The bare `except:` wraps `re.findall(...)[0]` and just falls back to `num = None`. IndexError matches the failure mode without swallowing anything else.